### PR TITLE
updating calendar display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-icons": "^5.5.0",
-        "tailwindcss": "^4.1.17",
-        "xml-js": "^1.6.11"
+        "tailwindcss": "^4.1.17"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -11235,18 +11234,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-icons": "^5.5.0",
-    "tailwindcss": "^4.1.17",
-    "xml-js": "^1.6.11"
+    "tailwindcss": "^4.1.17"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/components/Calendar.astro
+++ b/src/components/Calendar.astro
@@ -1,39 +1,96 @@
 ---
-import EventList from '../components/EventList.jsx';
-const RSS_URL = "https://www.meetup.com/Kyoto-Tech-Meetup/events/rss/";
+import EventList from "../components/EventList.jsx";
 
-const rssResponse = await fetch(RSS_URL);
-const rssText = await rssResponse.text();
+const EVENTS_URL = "https://www.meetup.com/kyoto-tech-meetup/events/";
 
-// Minimal XML → JS parser
-import { xml2js } from "xml-js";
-const parsed = xml2js(rssText, { compact: true });
-let eventNames = [];
+async function fetchMeetupEvents() {
+	const html = await fetch(EVENTS_URL).then((r) => r.text());
 
-if (Array.isArray(parsed.rss.channel.item)) {
+	// Grab the JSON embedded in the __NEXT_DATA__ script tag
+	const match = html.match(
+		/<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/
+	);
 
-  const items = parsed.rss.channel.item.map(evt => ({
-    title: evt.title._cdata,
-    link: evt.link._text,
-    pubDate: evt.pubDate._text,
-    description: evt.description?._text ?? "",
-    }));
+	if (!match?.[1]) return [];
 
-    
-  eventNames = items;
-  
-} else {
-  // handle the case where it's a single item object
-  eventNames= [];
+	const data = JSON.parse(match[1]);
+	const apolloState = data?.props?.pageProps?.__APOLLO_STATE__ as
+		| Record<string, any>
+		| undefined;
+	if (!apolloState) return [];
+
+	const now = new Date();
+	const cutoff = new Date();
+	cutoff.setDate(cutoff.getDate() + 60);
+
+	const resolvePhotoUrl = (photoLike: any) => {
+		const ref =
+			(typeof photoLike === "string" && photoLike.startsWith("PhotoInfo:"))
+				? photoLike
+				: photoLike?.__ref ??
+				  (photoLike?.id ? `PhotoInfo:${photoLike.id}` : null);
+
+		if (!ref) return null;
+		const photo = apolloState[ref];
+		if (!photo) return null;
+
+		return (
+			photo.highResUrl ??
+			photo.source ??
+			(photo.baseUrl && photo.id ? `${photo.baseUrl}${photo.id}` : null)
+		);
+	};
+
+	const resolveVenue = (venueLike: any) => {
+		const ref =
+			(typeof venueLike === "string" && venueLike.startsWith("Venue:"))
+				? venueLike
+				: venueLike?.__ref ??
+				  (venueLike?.id ? `Venue:${venueLike.id}` : null);
+
+		const venue = ref ? apolloState[ref] : venueLike;
+		if (!venue) return null;
+
+		return {
+			name: venue.name,
+			address: venue.address,
+			city: venue.city,
+			state: venue.state,
+			country: venue.country
+		};
+	};
+
+	const events = Object.entries(apolloState)
+		.filter(([key, value]) => key.startsWith("Event:") && (value as any)?.dateTime)
+		.map(([, rawValue]) => {
+			const value = rawValue as any;
+			return {
+				title: value.title?.replace(" | Kyoto Tech Meetup", "") ?? value.title,
+				link: value.eventUrl,
+				start: value.dateTime,
+				endTime: value.endTime ?? null,
+				description: value.description ?? "",
+				image: resolvePhotoUrl(value.featuredEventPhoto),
+				goingCount: value.going?.totalCount ?? 0,
+				interestedCount: value.socialProofInsights?.totalInterestedUsers ?? 0,
+				venue: resolveVenue(value.venue)
+			};
+		})
+		.filter((evt) => {
+			const start = new Date(evt.start);
+			return start >= now && start <= cutoff;
+		})
+		.sort((a, b) => new Date(a.start).valueOf() - new Date(b.start).valueOf());
+
+	return events;
 }
 
-console.log("hello" + eventNames);
+const events = await fetchMeetupEvents();
 
 ---
 
-<section class="p-6">
+<section class="pt-6 pb-6">
 
-  <EventList client:load events={eventNames} />
+  <EventList client:load events={events} />
 
 </section>
-

--- a/src/components/EventList.jsx
+++ b/src/components/EventList.jsx
@@ -3,27 +3,117 @@ export default function EventList({ events }) {
     return <p className=" mt3 text-gray-500 italic">Check back soon for events! <a href="https://www.meetup.com/ja-JP/kyoto-tech-meetup"> Join our meetup group here to get updates.</a></p>;
   }
 
+  // Group by month string (using Tokyo timezone for consistency)
+  const groups = events.reduce((acc, evt) => {
+    const d = new Date(evt.start);
+    const monthLabel = d.toLocaleString("en-US", {
+      timeZone: "Asia/Tokyo",
+      month: "long",
+      year: "numeric"
+    });
+    acc[monthLabel] = acc[monthLabel] || [];
+    acc[monthLabel].push(evt);
+    return acc;
+  }, {});
+
+  const orderedMonths = events
+    .map(evt => {
+      const d = new Date(evt.start);
+      const monthLabel = d.toLocaleString("en-US", {
+        timeZone: "Asia/Tokyo",
+        month: "long",
+        year: "numeric"
+      });
+      return { monthLabel, date: d };
+    })
+    .reduce((seen, curr) => {
+      if (!seen.find(item => item.monthLabel === curr.monthLabel)) {
+        seen.push(curr);
+      }
+      return seen;
+    }, [])
+    .sort((a, b) => a.date - b.date)
+    .map(item => item.monthLabel);
+
   return (
-    <ul className="space-y-6">
-      {events.map(event => (
-        <li key={event.link} className="p-4 border rounded-xl shadow-sm">
-          <a
-            href={event.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xl font-semibold text-blue-600 hover:underline"
-          >
-            {event.title}
-          </a>
-          <p className="text-sm text-gray-500 mt-1">
-            {new Date(event.pubDate).toLocaleString()}
-          </p>
-          <div
-            className="prose prose-sm mt-2"
-            dangerouslySetInnerHTML={{ __html: event.description }}
-          />
-        </li>
+    <div className="space-y-8">
+      {orderedMonths.map(monthLabel => (
+        <div key={monthLabel} className="space-y-4">
+          <h3 className="text-2xl font-semibold text-slate-900">{monthLabel}</h3>
+          <ul className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {groups[monthLabel].map(event => (
+              <li key={event.link}>
+                <a
+                  href={event.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-4 border rounded-xl shadow-sm flex gap-4 items-start md:items-center block hover:shadow-md transition-shadow no-underline h-full"
+                  style={{
+                    color: "var(--accent)",
+                    textDecoration: "none",
+                    borderColor: "var(--accent)"
+                  }}
+                >
+                  {event.image ? (
+                    <div className="w-1/3 min-w-[120px]">
+                      <img
+                        src={event.image}
+                        alt={event.title}
+                        className="w-full h-full max-h-32 rounded-lg object-cover"
+                        loading="lazy"
+                      />
+                    </div>
+                  ) : null}
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xl font-semibold">
+                      {event.title}
+                    </div>
+                    <p className="text-sm text-gray-500 mt-1 space-x-2">
+                      <span>
+                        {new Date(event.start).toLocaleString("en-US", {
+                          timeZone: "Asia/Tokyo",
+                          month: "long",
+                          day: "numeric",
+                          year: "numeric"
+                        })}
+                      </span>
+                      <span className="text-gray-400">•</span>
+                      <span>
+                        {new Date(event.start).toLocaleTimeString("en-US", {
+                          timeZone: "Asia/Tokyo",
+                          hour12: false,
+                          hour: "2-digit",
+                          minute: "2-digit"
+                        })}
+                        {event.endTime
+                          ? ` – ${new Date(event.endTime).toLocaleTimeString("en-US", {
+                              timeZone: "Asia/Tokyo",
+                              hour12: false,
+                              hour: "2-digit",
+                              minute: "2-digit"
+                            })}`
+                          : ""}
+                      </span>
+                    </p>
+                    <div className="text-sm text-gray-700 mt-2 space-y-1">
+                      <div className="font-medium text-slate-900">
+                        {event.venue?.name ?? "Venue TBA"}
+                      </div>
+                      {event.venue?.address ? (
+                        <div className="text-gray-600">{event.venue.address}</div>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3 mt-3 text-sm text-gray-600">
+                      <span>{event.goingCount ?? 0} going</span>
+                      <span>· {event.interestedCount ?? 0} interested</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
       ))}
-    </ul>
+    </div>
   );
 }

--- a/src/components/LanguagePicker.astro
+++ b/src/components/LanguagePicker.astro
@@ -1,19 +1,20 @@
 ---
-import { languages } from '../i18n/ui';
-import { getRelativeLocaleUrl } from 'astro:i18n';
+import { languages } from "../i18n/ui";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 const langsToFlags = {
 	en: "GB.svg",
 	ja: "JP.svg"
-};
+} as const;
 
-const activeLang = Astro.currentLocale;
-const allLangs = Object.entries(languages);
+const activeLang = Astro.currentLocale as "en" | "ja" | undefined;
+const allLangs = Object.entries(languages) as [keyof typeof languages, string][];
 
 ---
 <ul class="absolute top-4 right-4 md:top-6 md:right-6 z-20 flex gap-2">
 	{allLangs.map(([lang, label]) => {
 		const isActive = lang === activeLang;
+		const flag = langsToFlags[lang] ?? "";
 
 		return (
 			<li>
@@ -26,7 +27,7 @@ const allLangs = Object.entries(languages);
 				>
 					<span class="sr-only">{label}</span>
 					<img
-						src={`/flags/${langsToFlags[lang]}`}
+						src={`/flags/${flag}`}
 						alt=""
 						aria-hidden="true"
 						width="24"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,10 +1,10 @@
 ---
 import "../styles/global.css";
-import { useTranslations } from '../i18n/utils';
-import { getRelativeLocaleUrl } from 'astro:i18n';
+import { useTranslations } from "../i18n/utils";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
-const activeLang = Astro.currentLocale;
-const t = useTranslations(activeLang || 'en');
+const activeLang = (Astro.currentLocale ?? "en") as "en" | "ja";
+const t = useTranslations(activeLang);
 ---
 
 <!doctype html>
@@ -25,7 +25,7 @@ const t = useTranslations(activeLang || 'en');
 			property="og:description"
 			content={t("meta.description")}
 		/>
-		<meta property="og:url" content=`https://kyoto-tech.github.io${getRelativeLocaleUrl(activeLang, "/")}` />
+		<meta property="og:url" content={`https://kyoto-tech.github.io${getRelativeLocaleUrl(activeLang, "/")}`} />
 		<meta property="og:image" content="https://kyoto-tech.github.io/og/kyoto-tech-meetup.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,17 +3,16 @@ import Layout from "../layouts/Layout.astro";
 import WhyJoin from "../components/WhyJoin.astro";
 import WhatWeDo from "../components/WhatWeDo.astro";
 import Calendar from "../components/Calendar.astro";
-import EventList from "../components/EventList.jsx";
 import { FaGithub, FaDiscord, FaMeetup } from "react-icons/fa";
-import { useTranslations } from '../i18n/utils';
-import LanguagePicker from '../components/LanguagePicker.astro';
+import { useTranslations } from "../i18n/utils";
+import LanguagePicker from "../components/LanguagePicker.astro";
 
-const { lang = 'en' } = Astro.props;
+const { lang = "en" } = Astro.props;
 const t = useTranslations(lang);
 
-const meetupUrl = lang === 'ja'
-	? 'https://www.meetup.com/ja-JP/kyoto-tech-meetup/'
-	: 'https://www.meetup.com/kyoto-tech-meetup/';
+const meetupUrl = lang === "ja"
+	? "https://www.meetup.com/ja-JP/kyoto-tech-meetup/"
+	: "https://www.meetup.com/kyoto-tech-meetup/";
 
 type ActivityContent =
 	| {

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -1,4 +1,4 @@
 ---
-import RootIndex from '../index.astro';
+import RootIndex from "../index.astro";
 ---
 <RootIndex lang="ja" />


### PR DESCRIPTION
New method of meetup data fetching to pull accurate event details (venue info, counts, images) and filtered to the next 60 days.

Redesigned the event list: images on the left, 2-column grid grouped by month with headers, date in long format plus 24h time range, venue name/address, going/interested counts, and fully clickable cards with accent styling.

Cleaned up `npm run check` (lint/TS) issues: standardized double quotes, typed locale/flag lookups, tightened typing in Calendar.astro, removed unused imports, and dropped the unused xml-js dependency.