### PR TITLE
fix: removed hardcoded strings, synced translations for en and ja

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -4,9 +4,10 @@ type Props = {
   subtitle: string;
   ctaUrl: string;
   ctaLabel: string;
+  badge: string;
 };
 
-const { title, subtitle, ctaUrl, ctaLabel } = Astro.props as Props;
+const { title, subtitle, ctaUrl, ctaLabel, badge } = Astro.props as Props;
 const heroImageSrc =
   "https://images.unsplash.com/photo-1570463723985-41c39db0343d?q=80&w=1335&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D?auto=format&fit=crop&w=2000&q=80";
 ---
@@ -15,7 +16,7 @@ const heroImageSrc =
   <div class="px-6 py-12 md:px-16 md:py-16 text-center">
     <span class="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-600">
       <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
-      100+ Members &amp; Growing
+      {badge}
     </span>
     <h1 class="mt-4 text-4xl font-semibold leading-tight text-neutral-900 md:text-5xl">
       {title}

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -17,6 +17,7 @@ export const ui = {
       "Connect, learn, and build together in Japan's cultural heart",
     "home.header.subtitle":
       "Gatherings for developers, designers, researchers, and founders exploring technology in Kyoto.",
+    "home.header.badge": "100+ Members & Growing",
     "home.header.cta": "Join Us",
     "home.header.discordCta": "Join our Discord",
     "home.header.githubCta": "View our GitHub",
@@ -124,7 +125,13 @@ export const ui = {
 
     "home.hackDay.imageAlt": "Our first Community Hack Day where we built this very site!",
     "home.hackDay.caption": "Our first Community Hack Day where we built this very site!",
+    "home.hackDay.groupTitle": "Community Hack Days",
+    "home.hackDay2.imageAlt": "Our second Community Hack Day",
+    "home.hackDay2.caption": "Our second Community Hack Day",
     "home.hackDay.repoLink": "repo here",
+    "home.morningCoffee.groupTitle": "Morning Tech & Coffee",
+    "home.morningCoffee.imageAlt": "Morning Tech & Coffee meetup",
+    "home.morningCoffee.caption": "Morning Tech & Coffee",
 
     "home.footer.copyright":
       "Kyoto Tech Meetup. Crafted by volunteers in Kyoto.",
@@ -152,6 +159,7 @@ export const ui = {
       "日本の文化都市・京都でつながり、学び、ものづくりをしよう",
     "home.header.subtitle":
       "京都でテクノロジーを探求するデベロッパー、デザイナー、研究者、創業者のための集まりです。",
+    "home.header.badge": "メンバー100人以上＆拡大中",
     "home.header.cta": "参加する",
     "home.header.discordCta": "Discordでチャットする",
     "home.header.githubCta": "GitHubでコードを見る",
@@ -261,7 +269,13 @@ export const ui = {
 
     "home.hackDay.imageAlt": "初めてのCommunity Hack Day。このサイトもここで作りました！",
     "home.hackDay.caption": "初めてのCommunity Hack Day。このサイトもここで作りました！",
+    "home.hackDay.groupTitle": "Community Hack Days",
+    "home.hackDay2.imageAlt": "2回目のCommunity Hack Day",
+    "home.hackDay2.caption": "2回目のCommunity Hack Day",
     "home.hackDay.repoLink": "リポジトリはこちら",
+    "home.morningCoffee.groupTitle": "Morning Tech & Coffee",
+    "home.morningCoffee.imageAlt": "Morning Tech & Coffeeミートアップ",
+    "home.morningCoffee.caption": "Morning Tech & Coffee",
 
     "home.footer.copyright":
       "Kyoto Tech Meetup — 京都在住のボランティアによるコミュニティ運営。",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,32 +54,32 @@ const quickLinks = [
 
 const photoGroups = [
   {
-    title: "Community Hack Days",
+    titleKey: "home.hackDay.groupTitle",
     photos: [
       {
         src: "/images/kyoto-tech-meetup-hack-day.jpg",
-        alt: "Our first Community Hack Day where we built this very site!",
-        caption: "Our first Community Hack Day where we built this very site!",
+        altKey: "home.hackDay.imageAlt",
+        captionKey: "home.hackDay.caption",
         repoUrl: "https://github.com/kyoto-tech/kyoto-tech.github.io",
       },
       {
         src: "/images/kyoto-tech-meetup-hack-day_2.jpg",
-        alt: "Our second Community Hack Day",
-        caption: "Our second Community Hack Day",
+        altKey: "home.hackDay2.imageAlt",
+        captionKey: "home.hackDay2.caption",
         repoUrl: null,
       },
     ],
   },
   {
-    title: "Morning Tech & Coffee",
+    titleKey: "home.morningCoffee.groupTitle",
     photos: [
       {
         src: "/images/kyoto-tech-morning-tech-&-coffee.jpg",
-        alt: "Morning Tech & Coffee meetup",
-        caption: "Morning Tech & Coffee",
+        altKey: "home.morningCoffee.imageAlt",
+        captionKey: "home.morningCoffee.caption",
         repoUrl: null,
         content: "bottom",
-      }
+      },
     ],
   },
 ] as const;
@@ -238,6 +238,7 @@ const nextUpdate = compositeFeed?.generatedAt
       subtitle={t("home.header.subtitle")}
       ctaUrl={meetupUrl}
       ctaLabel={t("home.header.cta")}
+      badge={t("home.header.badge")}
     />
   </div>
 
@@ -470,7 +471,7 @@ const nextUpdate = compositeFeed?.generatedAt
         {photoGroups.map((group) => (
           <div class="mt-10">
             <h3 class="mb-4 text-base font-semibold uppercase tracking-widest text-slate-500">
-              {group.title}
+              {t(group.titleKey)}
             </h3>
         
             <div
@@ -484,7 +485,7 @@ const nextUpdate = compositeFeed?.generatedAt
                 >
                   <img
                     src={photo.src}
-                    alt={photo.alt}
+                    alt={t(photo.altKey)}
                     loading="lazy"
                     decoding="async"
                     class={`w-full h-[280px] rounded-3xl object-cover transition-transform duration-300 ${
@@ -495,7 +496,7 @@ const nextUpdate = compositeFeed?.generatedAt
                   />
         
                   <figcaption class="px-5 py-4 text-center text-sm font-medium text-slate-700">
-                    {photo.caption}
+                    {t(photo.captionKey)}
                     {photo.repoUrl && (
                       <>
                         <br />


### PR DESCRIPTION
## Changes 

Introduced translations (en + ja) and:
1. Removed hardcoded english string from badge's text in the hero section.
2. photogroups have translation keys now.