### PR TITLE
Fix community feed notifier without destinations

### DIFF
--- a/.github/workflows/community-feed-notifier.yml
+++ b/.github/workflows/community-feed-notifier.yml
@@ -68,4 +68,7 @@ jobs:
           if [ "$WORKFLOW_ALLOW_INITIAL_POSTS" = "true" ]; then
             args+=("--allow-initial-posts")
           fi
+          if [ -z "$DISCORD_WEBHOOK_URL" ] && [ -z "$COMMUNITY_FEED_GENERIC_WEBHOOK_URL" ]; then
+            args+=("--skip-without-destinations")
+          fi
           node scripts/community-feed-notifier.mjs "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ public/          # Files served as-is (favicon, images)
 - Required secret: `GH_GIST_TOKEN` with the `gist` scope.
 - Optional secret: `DISCORD_WEBHOOK_URL` for direct Discord posting.
 - Optional secret: `COMMUNITY_FEED_GENERIC_WEBHOOK_URL` for forwarding each new item as JSON to your own bot/service for X, LINE, or other destinations.
+- Scheduled runs skip notification work when no destination webhook secret is configured.
 
 ## Interacting with the community
 

--- a/scripts/community-feed-notifier.mjs
+++ b/scripts/community-feed-notifier.mjs
@@ -27,6 +27,7 @@ function parseArgs(argv) {
     dryRun: false,
     maxDeliveries: null,
     maxItemsPerFeed: DEFAULT_MAX_ITEMS_PER_FEED,
+    skipWithoutDestinations: false,
     suppressRemainingAfterLimit: false,
   };
 
@@ -43,6 +44,8 @@ function parseArgs(argv) {
     } else if (arg === "--max-items-per-feed" && argv[i + 1]) {
       args.maxItemsPerFeed = Number(argv[i + 1]);
       i += 1;
+    } else if (arg === "--skip-without-destinations") {
+      args.skipWithoutDestinations = true;
     } else if (arg === "--suppress-remaining-after-limit") {
       args.suppressRemainingAfterLimit = true;
     }
@@ -500,6 +503,13 @@ async function main() {
   const gistId = process.env.COMMUNITY_FEED_STATE_GIST_ID || "";
   const gistToken = process.env.GH_GIST_TOKEN || "";
   const destinations = getDestinations();
+
+  if (!destinations.length && !args.dryRun && args.skipWithoutDestinations) {
+    console.log(
+      "[notifier] No destinations configured; skipping notification run.",
+    );
+    return;
+  }
 
   if (!destinations.length && !args.dryRun) {
     throw new Error(


### PR DESCRIPTION
## Summary

- add an explicit skip mode for non-dry notifier runs with no configured destinations
- have the scheduled workflow pass that mode when both webhook secrets are absent
- document the scheduled skip behavior

## Why

Scheduled Community Feed Notifier runs currently fail immediately when no Discord or generic webhook destination secret is configured. That creates recurring red GitHub Actions runs even though there is nothing actionable for the notifier to send.

## Validation

- node scripts/community-feed-notifier.mjs --skip-without-destinations
- npm run feeds:notify:dry-run
- npm run check
- git diff --check