### PR TITLE
Add Vitest coverage and shared community feed reader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "knip": "^5.70.1",
         "sharp": "^0.34.5",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@astrojs/check": {
@@ -3146,6 +3147,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -3454,6 +3462,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3462,6 +3481,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3732,6 +3758,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/kit": {
@@ -4090,6 +4229,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -5054,6 +5203,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -6508,6 +6667,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -9771,6 +9940,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -10060,6 +10240,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -11082,6 +11269,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11152,6 +11346,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -11409,6 +11617,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -11432,6 +11647,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -12074,7 +12299,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12162,6 +12386,103 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/volar-service-css": {
       "version": "0.0.68",
@@ -12532,6 +12853,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "astro": "astro",
     "astrocheck": "astro check",
     "build": "npm run feeds:pull:stale-ok && astro build",
-    "check": "npm run lint; npm run tsc; npm run astrocheck; npm run images:check; npm run knip",
+    "check": "npm run lint; npm run test; npm run tsc; npm run astrocheck; npm run images:check; npm run knip",
     "dev": "astro dev",
     "feeds:notify": "node scripts/community-feed-notifier.mjs",
     "feeds:notify:dry-run": "node scripts/community-feed-notifier.mjs --dry-run",
@@ -17,6 +17,7 @@
     "knip": "knip",
     "lint": "eslint . --ext .js,.mjs,.ts,.tsx,.astro --no-warn-ignored",
     "preview": "astro preview",
+    "test": "vitest run",
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
@@ -44,6 +45,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "knip": "^5.70.1",
     "sharp": "^0.34.5",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/scripts/community-feed-notifier.mjs
+++ b/scripts/community-feed-notifier.mjs
@@ -1,8 +1,17 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import Parser from "rss-parser";
+import {
+  fetchFeedItems,
+  fetchJson,
+  fetchWithTimeout,
+  loadMemberFeeds,
+} from "./lib/community-feed-reader.mjs";
+import {
+  buildDiscordPayload,
+  buildMessage,
+  defaultState,
+  parseState,
+  upsertStateRecord,
+} from "./lib/community-feed-notifier-state.mjs";
 
-const MEMBER_FEEDS_PATH = path.resolve("src/data/member-feeds.json");
 const GITHUB_API_ROOT = "https://api.github.com";
 const DEFAULT_STATE_FILENAME = "community-feed-state.json";
 const DEFAULT_MAX_ITEMS_PER_FEED = Number(
@@ -14,12 +23,6 @@ const REQUEST_TIMEOUT_MS = Number(
 );
 const USER_AGENT =
   "Kyoto Tech Meetup community notifier (+https://kyototechmeetup.com)";
-const YOUTUBE_HOSTNAMES = new Set([
-  "youtube.com",
-  "www.youtube.com",
-  "m.youtube.com",
-]);
-const YOUTUBE_CHANNEL_ID_PATTERN = /^UC[\w-]{22}$/;
 
 function parseArgs(argv) {
   const args = {
@@ -58,204 +61,6 @@ function getStateFilename() {
   return process.env.COMMUNITY_FEED_STATE_GIST_FILENAME || DEFAULT_STATE_FILENAME;
 }
 
-async function loadMemberFeeds() {
-  const content = await fs.readFile(MEMBER_FEEDS_PATH, "utf8");
-  const parsed = JSON.parse(content);
-  if (!Array.isArray(parsed)) {
-    throw new Error(`Expected an array in ${MEMBER_FEEDS_PATH}`);
-  }
-
-  return parsed.map((item) => {
-    if (!item?.name || !item?.feedUrl || !item?.siteUrl) {
-      throw new Error(
-        `Missing required fields in member feed entry: ${JSON.stringify(item)}`,
-      );
-    }
-
-    return {
-      name: String(item.name),
-      feedUrl: String(item.feedUrl),
-      siteUrl: String(item.siteUrl),
-    };
-  });
-}
-
-function parseDate(rawItem) {
-  const raw =
-    rawItem.isoDate ||
-    rawItem.pubDate ||
-    rawItem.published ||
-    rawItem.updated ||
-    null;
-
-  if (!raw) return null;
-  const date = new Date(raw);
-  return Number.isNaN(date.valueOf()) ? null : date;
-}
-
-function stripHtml(value) {
-  if (!value || typeof value !== "string") return "";
-  return value.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
-}
-
-function truncate(value, max = 280) {
-  if (!value) return "";
-  return value.length > max ? `${value.slice(0, max - 3).trimEnd()}...` : value;
-}
-
-function fetchWithTimeout(url, options = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  return fetch(url, {
-    ...options,
-    signal: controller.signal,
-    headers: {
-      "user-agent": USER_AGENT,
-      ...(options.headers || {}),
-    },
-  }).finally(() => {
-    clearTimeout(timeout);
-  });
-}
-
-async function fetchJson(url, options = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
-  const response = await fetchWithTimeout(url, options, timeoutMs);
-  if (!response.ok) {
-    throw new Error(`Request failed for ${url}: HTTP ${response.status}`);
-  }
-  return response.json();
-}
-
-async function fetchText(url, options = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
-  const response = await fetchWithTimeout(url, options, timeoutMs);
-  if (!response.ok) {
-    throw new Error(`Request failed for ${url}: HTTP ${response.status}`);
-  }
-  return response.text();
-}
-
-function parseYoutubeChannelId(html) {
-  if (!html) return null;
-
-  const patterns = [
-    /"externalId":"(UC[\w-]{22})"/,
-    /"channelId":"(UC[\w-]{22})"/,
-    /youtube\.com\/channel\/(UC[\w-]{22})/,
-  ];
-
-  for (const pattern of patterns) {
-    const match = html.match(pattern);
-    if (match?.[1] && YOUTUBE_CHANNEL_ID_PATTERN.test(match[1])) {
-      return match[1];
-    }
-  }
-
-  return null;
-}
-
-async function resolveFeedUrl(feedUrl) {
-  let parsed;
-
-  try {
-    parsed = new URL(feedUrl);
-  } catch {
-    return feedUrl;
-  }
-
-  if (!YOUTUBE_HOSTNAMES.has(parsed.hostname)) return feedUrl;
-
-  const handleMatch = parsed.pathname.match(/^\/@([A-Za-z0-9._-]+)\/?$/);
-  if (!handleMatch) return feedUrl;
-
-  const channelPageHtml = await fetchText(feedUrl, {}, FEED_TIMEOUT_MS);
-  const channelId = parseYoutubeChannelId(channelPageHtml);
-  if (!channelId) {
-    throw new Error(`Could not resolve YouTube channel id from handle URL: ${feedUrl}`);
-  }
-
-  return `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
-}
-
-function normalizeItem(rawItem, source) {
-  const publishedAt = parseDate(rawItem);
-  if (!publishedAt) return null;
-
-  const rawId =
-    rawItem.guid ||
-    rawItem.id ||
-    rawItem.link ||
-    `${rawItem.title || "untitled"}#${publishedAt.toISOString()}`;
-
-  const summary =
-    rawItem.contentSnippet ||
-    stripHtml(rawItem["content:encoded"]) ||
-    stripHtml(rawItem.content) ||
-    stripHtml(rawItem.summary) ||
-    stripHtml(rawItem.description) ||
-    "";
-
-  return {
-    id: `${source.feedUrl}::${String(rawId)}`,
-    sourceItemId: String(rawId),
-    title: rawItem.title || "Untitled",
-    link: rawItem.link || source.siteUrl,
-    publishedAt: publishedAt.toISOString(),
-    summary: truncate(summary),
-    source,
-  };
-}
-
-async function fetchFeedItems(source, parser, maxItemsPerFeed) {
-  const resolvedFeedUrl = await resolveFeedUrl(source.feedUrl);
-  const xml = await fetchText(resolvedFeedUrl, {}, FEED_TIMEOUT_MS);
-  const parsed = await parser.parseString(xml);
-  const rawItems = parsed?.items || [];
-  const seenIds = new Set();
-
-  return rawItems
-    .map((rawItem) => normalizeItem(rawItem, source))
-    .filter(Boolean)
-    .filter((item) => {
-      if (seenIds.has(item.id)) return false;
-      seenIds.add(item.id);
-      return true;
-    })
-    .sort(
-      (a, b) =>
-        new Date(b.publishedAt).valueOf() - new Date(a.publishedAt).valueOf(),
-    )
-    .slice(0, Math.max(1, maxItemsPerFeed));
-}
-
-function defaultState() {
-  return {
-    version: 1,
-    initializedAt: null,
-    updatedAt: null,
-    items: {},
-  };
-}
-
-function parseState(content) {
-  const parsed = JSON.parse(content);
-
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return defaultState();
-  }
-
-  return {
-    version: Number(parsed.version) || 1,
-    initializedAt:
-      typeof parsed.initializedAt === "string" ? parsed.initializedAt : null,
-    updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : null,
-    items:
-      parsed.items && typeof parsed.items === "object" && !Array.isArray(parsed.items)
-        ? parsed.items
-        : {},
-  };
-}
-
 async function readStateFromGist(gistId, token) {
   const headers = {
     Accept: "application/vnd.github+json",
@@ -269,6 +74,7 @@ async function readStateFromGist(gistId, token) {
     `${GITHUB_API_ROOT}/gists/${gistId}`,
     { headers },
     REQUEST_TIMEOUT_MS,
+    USER_AGENT,
   );
   const stateFile = gist?.files?.[getStateFilename()];
 
@@ -304,6 +110,7 @@ async function writeStateToGist(gistId, token, state) {
       body: JSON.stringify(payload),
     },
     REQUEST_TIMEOUT_MS,
+    USER_AGENT,
   );
 
   if (!response.ok) {
@@ -312,59 +119,6 @@ async function writeStateToGist(gistId, token, state) {
       `Failed to update gist state: HTTP ${response.status} ${body}`.trim(),
     );
   }
-}
-
-function upsertStateRecord(state, item, seenAt, options = {}) {
-  const existing = state.items[item.id];
-  const record = {
-    id: item.id,
-    sourceItemId: item.sourceItemId,
-    title: item.title,
-    link: item.link,
-    publishedAt: item.publishedAt,
-    summary: item.summary || null,
-    source: item.source,
-    firstSeenAt: existing?.firstSeenAt || seenAt,
-    lastSeenAt: seenAt,
-    suppressed:
-      typeof existing?.suppressed === "boolean"
-        ? existing.suppressed
-        : Boolean(options.suppressed),
-    channels:
-      existing?.channels && typeof existing.channels === "object"
-        ? existing.channels
-        : {},
-  };
-
-  state.items[item.id] = record;
-  return record;
-}
-
-function buildMessage(item) {
-  return [`New community post from ${item.source.name}`, item.title, item.link].join(
-    "\n",
-  );
-}
-
-function buildDiscordPayload(item) {
-  return {
-    content: `New community post from **${item.source.name}**`,
-    embeds: [
-      {
-        title: item.title,
-        url: item.link,
-        description: item.summary || undefined,
-        timestamp: item.publishedAt,
-        author: {
-          name: item.source.name,
-          url: item.source.siteUrl,
-        },
-        footer: {
-          text: item.source.siteUrl,
-        },
-      },
-    ],
-  };
 }
 
 async function sendDiscordNotification(item) {
@@ -379,6 +133,7 @@ async function sendDiscordNotification(item) {
       body: JSON.stringify(buildDiscordPayload(item)),
     },
     REQUEST_TIMEOUT_MS,
+    USER_AGENT,
   );
 
   if (!response.ok) {
@@ -408,6 +163,7 @@ async function sendGenericWebhookNotification(item) {
       }),
     },
     REQUEST_TIMEOUT_MS,
+    USER_AGENT,
   );
 
   if (!response.ok) {
@@ -522,13 +278,16 @@ async function main() {
   }
 
   const memberFeeds = await loadMemberFeeds();
-  const parser = new Parser();
   const fetchFailures = [];
   const allItems = [];
 
   for (const source of memberFeeds) {
     try {
-      const items = await fetchFeedItems(source, parser, args.maxItemsPerFeed);
+      const items = await fetchFeedItems(source, {
+        feedTimeoutMs: FEED_TIMEOUT_MS,
+        maxItemsPerFeed: args.maxItemsPerFeed,
+        userAgent: USER_AGENT,
+      });
       allItems.push(...items);
     } catch (error) {
       fetchFailures.push({

--- a/scripts/fetch-feeds.mjs
+++ b/scripts/fetch-feeds.mjs
@@ -2,6 +2,16 @@ import fs from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import Parser from "rss-parser";
+import {
+  fetchRawFeedItems,
+  fetchText,
+  isYoutubeUrl,
+  loadMemberFeeds,
+  normalizeAndLimitFeedItems,
+  parseDate,
+  stripHtml,
+  truncate,
+} from "./lib/community-feed-reader.mjs";
 
 const DEFAULT_OUTPUT_PATH = path.resolve(
   process.env.COMPOSITE_FEED_OUTPUT || "src/data/composite-feed.json",
@@ -15,13 +25,6 @@ const ITEM_PAGE_TIMEOUT_MS = Number(
 );
 const USER_AGENT =
   "Kyoto Tech Meetup feed aggregator (+https://kyototechmeetup.com)";
-const MEMBER_FEEDS_PATH = path.resolve("src/data/member-feeds.json");
-const YOUTUBE_HOSTNAMES = new Set([
-  "youtube.com",
-  "www.youtube.com",
-  "m.youtube.com",
-]);
-const YOUTUBE_CHANNEL_ID_PATTERN = /^UC[\w-]{22}$/;
 
 function parseArgs(argv) {
   const args = {
@@ -44,58 +47,6 @@ function parseArgs(argv) {
   }
 
   return args;
-}
-
-async function loadMemberFeeds() {
-  const content = await fs.readFile(MEMBER_FEEDS_PATH, "utf8");
-  const parsed = JSON.parse(content);
-  if (!Array.isArray(parsed)) {
-    throw new Error(`Expected an array in ${MEMBER_FEEDS_PATH}`);
-  }
-  return parsed.map((item) => {
-    if (!item?.name || !item?.feedUrl || !item?.siteUrl) {
-      throw new Error(
-        `Missing required fields in member feed entry: ${JSON.stringify(item)}`,
-      );
-    }
-    return {
-      name: String(item.name),
-      feedUrl: String(item.feedUrl),
-      siteUrl: String(item.siteUrl),
-    };
-  });
-}
-
-function parseDate(rawItem) {
-  const raw =
-    rawItem.isoDate ||
-    rawItem.pubDate ||
-    rawItem.published ||
-    rawItem.updated ||
-    null;
-  if (!raw) return null;
-  const date = new Date(raw);
-  return Number.isNaN(date.valueOf()) ? null : date;
-}
-
-function stripHtml(value) {
-  if (!value || typeof value !== "string") return "";
-  return value.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
-}
-
-function truncate(value, max = 320) {
-  if (!value) return "";
-  return value.length > max ? `${value.slice(0, max - 3).trimEnd()}...` : value;
-}
-
-function isYoutubeUrl(value) {
-  if (!value || typeof value !== "string") return false;
-  try {
-    const parsed = new URL(value);
-    return YOUTUBE_HOSTNAMES.has(parsed.hostname) || parsed.hostname === "youtu.be";
-  } catch {
-    return false;
-  }
 }
 
 function extractMediaUrl(value) {
@@ -265,7 +216,7 @@ function extractYoutubeVideoId(rawItem) {
       const fromPath = normalizeYoutubeVideoId(link.pathname.replace(/^\//, ""));
       if (fromPath) return fromPath;
     }
-    if (YOUTUBE_HOSTNAMES.has(link.hostname) || link.hostname === "music.youtube.com") {
+    if (isYoutubeUrl(link.href) || link.hostname === "music.youtube.com") {
       const fromQuery = normalizeYoutubeVideoId(link.searchParams.get("v"));
       if (fromQuery) return fromQuery;
 
@@ -361,29 +312,6 @@ function normalizeItem(rawItem, source) {
   };
 }
 
-async function fetchWithTimeout(url, timeoutMs) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    let res;
-    try {
-      res = await fetch(url, {
-        signal: controller.signal,
-        headers: { "user-agent": USER_AGENT },
-      });
-    } catch (error) {
-      throw new Error(`Request failed for ${url}: ${error?.message || String(error)}`);
-    }
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    }
-    return await res.text();
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
 async function enrichItemWithLinkedPageImage(item) {
   if (item?.image || typeof item?.link !== "string") return item;
   if (!item.link.startsWith("http://") && !item.link.startsWith("https://")) {
@@ -391,7 +319,7 @@ async function enrichItemWithLinkedPageImage(item) {
   }
 
   try {
-    const html = await fetchWithTimeout(item.link, ITEM_PAGE_TIMEOUT_MS);
+    const html = await fetchText(item.link, {}, ITEM_PAGE_TIMEOUT_MS, USER_AGENT);
     const image = extractPageImage(html, item.link);
     if (!image) return item;
     return {
@@ -401,51 +329,6 @@ async function enrichItemWithLinkedPageImage(item) {
   } catch {
     return item;
   }
-}
-
-function parseYoutubeChannelId(html) {
-  if (!html) return null;
-  const patterns = [
-    /"externalId":"(UC[\w-]{22})"/,
-    /"channelId":"(UC[\w-]{22})"/,
-    /youtube\.com\/channel\/(UC[\w-]{22})/,
-  ];
-  for (const pattern of patterns) {
-    const match = html.match(pattern);
-    if (match?.[1] && YOUTUBE_CHANNEL_ID_PATTERN.test(match[1])) {
-      return match[1];
-    }
-  }
-  return null;
-}
-
-async function resolveFeedUrl(feedUrl) {
-  let parsed;
-  try {
-    parsed = new URL(feedUrl);
-  } catch {
-    return feedUrl;
-  }
-
-  if (!YOUTUBE_HOSTNAMES.has(parsed.hostname)) return feedUrl;
-
-  const handleMatch = parsed.pathname.match(/^\/@([A-Za-z0-9._-]+)\/?$/);
-  if (!handleMatch) return feedUrl;
-
-  const channelPageHtml = await fetchWithTimeout(feedUrl, FEED_TIMEOUT_MS);
-  const channelId = parseYoutubeChannelId(channelPageHtml);
-  if (!channelId) {
-    throw new Error(`Could not resolve YouTube channel id from handle URL: ${feedUrl}`);
-  }
-
-  return `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
-}
-
-async function fetchFeed(source, parser) {
-  const resolvedFeedUrl = await resolveFeedUrl(source.feedUrl);
-  const xml = await fetchWithTimeout(resolvedFeedUrl, FEED_TIMEOUT_MS);
-  const parsed = await parser.parseString(xml);
-  return parsed?.items || [];
 }
 
 async function writeOutput(filePath, payload) {
@@ -474,22 +357,15 @@ async function main() {
 
   for (const source of memberFeeds) {
     try {
-      const rawItems = await fetchFeed(source, parser);
-      const seenIds = new Set();
-      const normalizedItems = rawItems
-        .map((rawItem) => normalizeItem(rawItem, source))
-        .filter(Boolean)
-        .filter((item) => {
-          if (seenIds.has(item.id)) return false;
-          seenIds.add(item.id);
-          return true;
-        })
-        .sort(
-          (a, b) =>
-            new Date(b.publishedAt).valueOf() -
-            new Date(a.publishedAt).valueOf(),
-        )
-        .slice(0, Math.max(1, args.itemsPerFeed));
+      const rawItems = await fetchRawFeedItems(source, {
+        parser,
+        feedTimeoutMs: FEED_TIMEOUT_MS,
+        userAgent: USER_AGENT,
+      });
+      const normalizedItems = normalizeAndLimitFeedItems(rawItems, source, {
+        maxItemsPerFeed: args.itemsPerFeed,
+        normalizeItem,
+      });
 
       const itemsWithLinkedPageImages = await Promise.all(
         normalizedItems.map((item) => enrichItemWithLinkedPageImage(item)),

--- a/scripts/lib/community-feed-notifier-state.mjs
+++ b/scripts/lib/community-feed-notifier-state.mjs
@@ -1,0 +1,83 @@
+export function defaultState() {
+  return {
+    version: 1,
+    initializedAt: null,
+    updatedAt: null,
+    items: {},
+  };
+}
+
+export function parseState(content) {
+  const parsed = JSON.parse(content);
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return defaultState();
+  }
+
+  return {
+    version: Number(parsed.version) || 1,
+    initializedAt:
+      typeof parsed.initializedAt === "string" ? parsed.initializedAt : null,
+    updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : null,
+    items:
+      parsed.items && typeof parsed.items === "object" && !Array.isArray(parsed.items)
+        ? parsed.items
+        : {},
+  };
+}
+
+export function upsertStateRecord(state, item, seenAt, options = {}) {
+  const existing = state.items[item.id];
+  const record = {
+    id: item.id,
+    sourceItemId: item.sourceItemId,
+    title: item.title,
+    link: item.link,
+    publishedAt: item.publishedAt,
+    summary: item.summary || null,
+    source: item.source,
+    firstSeenAt: existing?.firstSeenAt || seenAt,
+    lastSeenAt: seenAt,
+    suppressed:
+      typeof existing?.suppressed === "boolean"
+        ? existing.suppressed
+        : Boolean(options.suppressed),
+    channels:
+      existing?.channels && typeof existing.channels === "object"
+        ? existing.channels
+        : {},
+  };
+
+  state.items[item.id] = record;
+  return record;
+}
+
+export function buildMessage(item) {
+  return [`New community post from ${item.source.name}`, item.title, item.link].join(
+    "\n",
+  );
+}
+
+export function buildDiscordPayload(item) {
+  const embed = {
+    title: item.title,
+    url: item.link,
+    timestamp: item.publishedAt,
+    author: {
+      name: item.source.name,
+      url: item.source.siteUrl,
+    },
+    footer: {
+      text: item.source.siteUrl,
+    },
+  };
+
+  if (item.summary) {
+    embed.description = item.summary;
+  }
+
+  return {
+    content: `New community post from **${item.source.name}**`,
+    embeds: [embed],
+  };
+}

--- a/scripts/lib/community-feed-reader.mjs
+++ b/scripts/lib/community-feed-reader.mjs
@@ -1,0 +1,263 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import Parser from "rss-parser";
+
+const DEFAULT_MEMBER_FEEDS_PATH = path.resolve("src/data/member-feeds.json");
+const DEFAULT_FEED_TIMEOUT_MS = 12000;
+const DEFAULT_USER_AGENT =
+  "Kyoto Tech Meetup feed reader (+https://kyototechmeetup.com)";
+
+const YOUTUBE_HOSTNAMES = new Set([
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+]);
+const YOUTUBE_CHANNEL_ID_PATTERN = /^UC[\w-]{22}$/;
+
+export async function loadMemberFeeds(filePath = DEFAULT_MEMBER_FEEDS_PATH) {
+  const content = await fs.readFile(filePath, "utf8");
+  const parsed = JSON.parse(content);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Expected an array in ${filePath}`);
+  }
+
+  return parsed.map((item) => {
+    if (!item?.name || !item?.feedUrl || !item?.siteUrl) {
+      throw new Error(
+        `Missing required fields in member feed entry: ${JSON.stringify(item)}`,
+      );
+    }
+
+    return {
+      name: String(item.name),
+      feedUrl: String(item.feedUrl),
+      siteUrl: String(item.siteUrl),
+    };
+  });
+}
+
+export function parseDate(rawItem) {
+  const raw =
+    rawItem.isoDate ||
+    rawItem.pubDate ||
+    rawItem.published ||
+    rawItem.updated ||
+    null;
+
+  if (!raw) return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.valueOf()) ? null : date;
+}
+
+export function stripHtml(value) {
+  if (!value || typeof value !== "string") return "";
+  return value.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+export function truncate(value, max = 280) {
+  if (!value) return "";
+  return value.length > max ? `${value.slice(0, max - 3).trimEnd()}...` : value;
+}
+
+export function isYoutubeUrl(value) {
+  if (!value || typeof value !== "string") return false;
+  try {
+    const parsed = new URL(value);
+    return YOUTUBE_HOSTNAMES.has(parsed.hostname) || parsed.hostname === "youtu.be";
+  } catch {
+    return false;
+  }
+}
+
+export function fetchWithTimeout(
+  url,
+  options = {},
+  timeoutMs = DEFAULT_FEED_TIMEOUT_MS,
+  userAgent = DEFAULT_USER_AGENT,
+) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  return fetch(url, {
+    ...options,
+    signal: controller.signal,
+    headers: {
+      ...(userAgent ? { "user-agent": userAgent } : {}),
+      ...(options.headers || {}),
+    },
+  }).finally(() => {
+    clearTimeout(timeout);
+  });
+}
+
+export async function fetchText(
+  url,
+  options = {},
+  timeoutMs = DEFAULT_FEED_TIMEOUT_MS,
+  userAgent = DEFAULT_USER_AGENT,
+) {
+  const response = await fetchWithTimeout(url, options, timeoutMs, userAgent);
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: HTTP ${response.status}`);
+  }
+  return response.text();
+}
+
+export async function fetchJson(
+  url,
+  options = {},
+  timeoutMs = DEFAULT_FEED_TIMEOUT_MS,
+  userAgent = DEFAULT_USER_AGENT,
+) {
+  const response = await fetchWithTimeout(url, options, timeoutMs, userAgent);
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+export function parseYoutubeChannelId(html) {
+  if (!html) return null;
+
+  const patterns = [
+    /"externalId":"(UC[\w-]{22})"/,
+    /"channelId":"(UC[\w-]{22})"/,
+    /youtube\.com\/channel\/(UC[\w-]{22})/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1] && YOUTUBE_CHANNEL_ID_PATTERN.test(match[1])) {
+      return match[1];
+    }
+  }
+
+  return null;
+}
+
+export async function resolveFeedUrl(
+  feedUrl,
+  {
+    fetchTextFn = fetchText,
+    feedTimeoutMs = DEFAULT_FEED_TIMEOUT_MS,
+    userAgent = DEFAULT_USER_AGENT,
+  } = {},
+) {
+  let parsed;
+
+  try {
+    parsed = new URL(feedUrl);
+  } catch {
+    return feedUrl;
+  }
+
+  if (!YOUTUBE_HOSTNAMES.has(parsed.hostname)) return feedUrl;
+
+  const handleMatch = parsed.pathname.match(/^\/@([A-Za-z0-9._-]+)\/?$/);
+  if (!handleMatch) return feedUrl;
+
+  const channelPageHtml = await fetchTextFn(feedUrl, {}, feedTimeoutMs, userAgent);
+  const channelId = parseYoutubeChannelId(channelPageHtml);
+  if (!channelId) {
+    throw new Error(`Could not resolve YouTube channel id from handle URL: ${feedUrl}`);
+  }
+
+  return `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+}
+
+export function normalizeNotifierItem(rawItem, source) {
+  const publishedAt = parseDate(rawItem);
+  if (!publishedAt) return null;
+
+  const rawId =
+    rawItem.guid ||
+    rawItem.id ||
+    rawItem.link ||
+    `${rawItem.title || "untitled"}#${publishedAt.toISOString()}`;
+
+  const summary =
+    rawItem.contentSnippet ||
+    stripHtml(rawItem["content:encoded"]) ||
+    stripHtml(rawItem.content) ||
+    stripHtml(rawItem.summary) ||
+    stripHtml(rawItem.description) ||
+    "";
+
+  return {
+    id: `${source.feedUrl}::${String(rawId)}`,
+    sourceItemId: String(rawId),
+    title: rawItem.title || "Untitled",
+    link: rawItem.link || source.siteUrl,
+    publishedAt: publishedAt.toISOString(),
+    summary: truncate(summary),
+    source,
+  };
+}
+
+export function normalizeAndLimitFeedItems(
+  rawItems,
+  source,
+  {
+    maxItemsPerFeed = 10,
+    normalizeItem = normalizeNotifierItem,
+  } = {},
+) {
+  const seenIds = new Set();
+
+  return rawItems
+    .map((rawItem) => normalizeItem(rawItem, source))
+    .filter(Boolean)
+    .filter((item) => {
+      if (seenIds.has(item.id)) return false;
+      seenIds.add(item.id);
+      return true;
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.publishedAt).valueOf() - new Date(a.publishedAt).valueOf(),
+    )
+    .slice(0, Math.max(1, maxItemsPerFeed));
+}
+
+export async function fetchRawFeedItems(
+  source,
+  {
+    parser = new Parser(),
+    fetchTextFn = fetchText,
+    feedTimeoutMs = DEFAULT_FEED_TIMEOUT_MS,
+    userAgent = DEFAULT_USER_AGENT,
+  } = {},
+) {
+  const resolvedFeedUrl = await resolveFeedUrl(source.feedUrl, {
+    fetchTextFn,
+    feedTimeoutMs,
+    userAgent,
+  });
+  const xml = await fetchTextFn(resolvedFeedUrl, {}, feedTimeoutMs, userAgent);
+  const parsed = await parser.parseString(xml);
+  return parsed?.items || [];
+}
+
+export async function fetchFeedItems(
+  source,
+  {
+    parser = new Parser(),
+    fetchTextFn = fetchText,
+    feedTimeoutMs = DEFAULT_FEED_TIMEOUT_MS,
+    userAgent = DEFAULT_USER_AGENT,
+    maxItemsPerFeed = 10,
+    normalizeItem = normalizeNotifierItem,
+  } = {},
+) {
+  const rawItems = await fetchRawFeedItems(source, {
+    parser,
+    fetchTextFn,
+    feedTimeoutMs,
+    userAgent,
+  });
+
+  return normalizeAndLimitFeedItems(rawItems, source, {
+    maxItemsPerFeed,
+    normalizeItem,
+  });
+}

--- a/test/community-feed-notifier-state.test.mjs
+++ b/test/community-feed-notifier-state.test.mjs
@@ -1,0 +1,142 @@
+import { expect, test } from "vitest";
+import {
+  buildDiscordPayload,
+  buildMessage,
+  defaultState,
+  parseState,
+  upsertStateRecord,
+} from "../scripts/lib/community-feed-notifier-state.mjs";
+
+function sampleItem(overrides = {}) {
+  return {
+    id: "https://example.com/feed.xml::post-1",
+    sourceItemId: "post-1",
+    title: "Post One",
+    link: "https://example.com/post-1",
+    publishedAt: "2026-04-25T05:35:48.687Z",
+    summary: "A useful post",
+    source: {
+      name: "Example Author",
+      feedUrl: "https://example.com/feed.xml",
+      siteUrl: "https://example.com/",
+    },
+    ...overrides,
+  };
+}
+
+test("defaultState creates an empty notifier state", () => {
+  expect(defaultState()).toEqual({
+    version: 1,
+    initializedAt: null,
+    updatedAt: null,
+    items: {},
+  });
+});
+
+test("parseState normalizes missing or malformed state fields", () => {
+  expect(parseState("null")).toEqual(defaultState());
+  expect(
+    parseState(
+      JSON.stringify({
+        version: "2",
+        initializedAt: 123,
+        updatedAt: "2026-04-25T05:35:48.687Z",
+        items: [],
+      }),
+    ),
+  ).toEqual({
+    version: 2,
+    initializedAt: null,
+    updatedAt: "2026-04-25T05:35:48.687Z",
+    items: {},
+  });
+});
+
+test("upsertStateRecord inserts a new item with suppression and channel defaults", () => {
+  const state = defaultState();
+  const record = upsertStateRecord(
+    state,
+    sampleItem(),
+    "2026-04-25T06:00:00.000Z",
+    { suppressed: true },
+  );
+
+  expect(record).toMatchObject({
+    id: "https://example.com/feed.xml::post-1",
+    sourceItemId: "post-1",
+    firstSeenAt: "2026-04-25T06:00:00.000Z",
+    lastSeenAt: "2026-04-25T06:00:00.000Z",
+    suppressed: true,
+    channels: {},
+  });
+  expect(state.items[record.id]).toBe(record);
+});
+
+test("upsertStateRecord preserves firstSeenAt, suppression, and delivery channels", () => {
+  const item = sampleItem();
+  const state = {
+    ...defaultState(),
+    items: {
+      [item.id]: {
+        ...item,
+        firstSeenAt: "2026-04-24T00:00:00.000Z",
+        lastSeenAt: "2026-04-24T00:00:00.000Z",
+        suppressed: false,
+        channels: {
+          discord: {
+            deliveredAt: "2026-04-24T00:01:00.000Z",
+          },
+        },
+      },
+    },
+  };
+
+  const record = upsertStateRecord(
+    state,
+    sampleItem({ title: "Updated title" }),
+    "2026-04-25T06:00:00.000Z",
+    { suppressed: true },
+  );
+
+  expect(record.firstSeenAt).toBe("2026-04-24T00:00:00.000Z");
+  expect(record.lastSeenAt).toBe("2026-04-25T06:00:00.000Z");
+  expect(record.suppressed).toBe(false);
+  expect(record.channels.discord.deliveredAt).toBe("2026-04-24T00:01:00.000Z");
+  expect(record.title).toBe("Updated title");
+});
+
+test("buildMessage formats a plain text destination message", () => {
+  expect(buildMessage(sampleItem())).toBe(
+    [
+      "New community post from Example Author",
+      "Post One",
+      "https://example.com/post-1",
+    ].join("\n"),
+  );
+});
+
+test("buildDiscordPayload formats the Discord webhook payload", () => {
+  expect(buildDiscordPayload(sampleItem())).toEqual({
+    content: "New community post from **Example Author**",
+    embeds: [
+      {
+        title: "Post One",
+        url: "https://example.com/post-1",
+        description: "A useful post",
+        timestamp: "2026-04-25T05:35:48.687Z",
+        author: {
+          name: "Example Author",
+          url: "https://example.com/",
+        },
+        footer: {
+          text: "https://example.com/",
+        },
+      },
+    ],
+  });
+});
+
+test("buildDiscordPayload omits empty summaries from embed description", () => {
+  const payload = buildDiscordPayload(sampleItem({ summary: "" }));
+  expect(payload.embeds[0]).not.toHaveProperty("description");
+});

--- a/test/community-feed-reader.test.mjs
+++ b/test/community-feed-reader.test.mjs
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "vitest";
+import {
+  fetchFeedItems,
+  loadMemberFeeds,
+  normalizeNotifierItem,
+  parseDate,
+  parseYoutubeChannelId,
+  resolveFeedUrl,
+  stripHtml,
+  truncate,
+} from "../scripts/lib/community-feed-reader.mjs";
+
+test("loadMemberFeeds normalizes valid source entries", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "feed-reader-"));
+  const filePath = path.join(tempDir, "member-feeds.json");
+  await fs.writeFile(
+    filePath,
+    JSON.stringify([
+      {
+        name: "Example Author",
+        feedUrl: "https://example.com/feed.xml",
+        siteUrl: "https://example.com/",
+      },
+    ]),
+  );
+
+  await expect(loadMemberFeeds(filePath)).resolves.toEqual([
+    {
+      name: "Example Author",
+      feedUrl: "https://example.com/feed.xml",
+      siteUrl: "https://example.com/",
+    },
+  ]);
+});
+
+test("loadMemberFeeds rejects malformed source entries", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "feed-reader-"));
+  const filePath = path.join(tempDir, "member-feeds.json");
+  await fs.writeFile(filePath, JSON.stringify([{ name: "Missing URLs" }]));
+
+  await expect(loadMemberFeeds(filePath)).rejects.toThrow(
+    /Missing required fields in member feed entry/,
+  );
+});
+
+test("parseDate accepts common RSS date fields and rejects invalid dates", () => {
+  expect(
+    parseDate({ isoDate: "2026-04-25T05:35:48.687Z" }).toISOString(),
+  ).toBe("2026-04-25T05:35:48.687Z");
+  expect(
+    parseDate({ pubDate: "Sat, 25 Apr 2026 05:35:48 GMT" }).toISOString(),
+  ).toBe("2026-04-25T05:35:48.000Z");
+  expect(parseDate({ isoDate: "not a date" })).toBeNull();
+  expect(parseDate({})).toBeNull();
+});
+
+test("stripHtml and truncate produce stable summaries", () => {
+  expect(stripHtml("<p>Hello <strong>Kyoto</strong></p>")).toBe("Hello Kyoto");
+  expect(truncate("abcdef", 6)).toBe("abcdef");
+  expect(truncate("abcdef", 5)).toBe("ab...");
+});
+
+test("resolveFeedUrl resolves YouTube handles to channel feeds", async () => {
+  const resolved = await resolveFeedUrl("https://www.youtube.com/@example", {
+    fetchTextFn: async () =>
+      '{"externalId":"UC1234567890123456789012","title":"Example"}',
+  });
+
+  expect(resolved).toBe(
+    "https://www.youtube.com/feeds/videos.xml?channel_id=UC1234567890123456789012",
+  );
+});
+
+test("parseYoutubeChannelId supports common channel id locations", () => {
+  expect(
+    parseYoutubeChannelId('{"channelId":"UCabcdefabcdefabcdefabcd"}'),
+  ).toBe("UCabcdefabcdefabcdefabcd");
+  expect(
+    parseYoutubeChannelId("https://www.youtube.com/channel/UCabcdefabcdefabcdefabcd"),
+  ).toBe("UCabcdefabcdefabcdefabcd");
+  expect(parseYoutubeChannelId("no channel here")).toBeNull();
+});
+
+test("normalizeNotifierItem preserves notifier item identity format", () => {
+  const source = {
+    name: "Example Author",
+    feedUrl: "https://example.com/feed.xml",
+    siteUrl: "https://example.com/",
+  };
+  const item = normalizeNotifierItem(
+    {
+      guid: "post-1",
+      title: "Post One",
+      link: "https://example.com/post-1",
+      isoDate: "2026-04-25T05:35:48.687Z",
+      description: "<p>A useful post</p>",
+    },
+    source,
+  );
+
+  expect(item.id).toBe("https://example.com/feed.xml::post-1");
+  expect(item.sourceItemId).toBe("post-1");
+  expect(item.summary).toBe("A useful post");
+  expect(item.source).toEqual(source);
+});
+
+test("fetchFeedItems fetches, normalizes, dedupes, sorts, and limits items", async () => {
+  const source = {
+    name: "Example Author",
+    feedUrl: "https://example.com/feed.xml",
+    siteUrl: "https://example.com/",
+  };
+  const parser = {
+    async parseString(xml) {
+      expect(xml).toBe("<rss />");
+      return {
+        items: [
+          {
+            guid: "old",
+            title: "Old",
+            link: "https://example.com/old",
+            isoDate: "2026-01-01T00:00:00.000Z",
+          },
+          {
+            guid: "new",
+            title: "New",
+            link: "https://example.com/new",
+            isoDate: "2026-04-01T00:00:00.000Z",
+          },
+          {
+            guid: "new",
+            title: "New duplicate",
+            link: "https://example.com/new-duplicate",
+            isoDate: "2026-04-02T00:00:00.000Z",
+          },
+        ],
+      };
+    },
+  };
+
+  const items = await fetchFeedItems(source, {
+    parser,
+    fetchTextFn: async (url) => {
+      expect(url).toBe("https://example.com/feed.xml");
+      return "<rss />";
+    },
+    maxItemsPerFeed: 2,
+  });
+
+  expect(items.map((item) => item.sourceItemId)).toEqual(["new", "old"]);
+});


### PR DESCRIPTION
## Summary

- add Vitest and wire `npm run test` into `npm run check`
- extract shared community feed reading/parsing logic into `scripts/lib/community-feed-reader.mjs`
- update the site feed generator and notifier to use the shared reader
- extract notifier state/message payload helpers into `scripts/lib/community-feed-notifier-state.mjs`
- add deterministic unit coverage for feed parsing, notifier state handling, and Discord/generic message payloads

## Why

The homepage feed generator and Community Feed Notifier had duplicated feed-source loading, YouTube handle resolution, RSS fetching, item normalization, sorting, and dedupe behavior. This consolidates that shared behavior while keeping each script's separate responsibilities intact:

- `scripts/fetch-feeds.mjs` still owns composite feed JSON output and site image enrichment
- `scripts/community-feed-notifier.mjs` still owns gist state I/O and destination delivery

## Validation

- `npm run test`
- `npm run check`
- `npm run feeds:pull -- --output /tmp/kyoto-tech/composite-feed-test.json`
- `env COMMUNITY_FEED_STATE_GIST_ID=f95dd7597eec170d738d905e3666bfc6 npm run feeds:notify:dry-run`
- `node scripts/community-feed-notifier.mjs --skip-without-destinations`
- `git diff --check`
