### PR TITLE
Stabilize community feed item IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ public/          # Files served as-is (favicon, images)
 ## Community Feed Notifier
 
 - The notifier reads approved sources from `src/data/member-feeds.json`.
+- Each feed source has a stable `id`; do not change it casually because notifier state keys are derived from it.
 - State lives in the public gist `f95dd7597eec170d738d905e3666bfc6` as `community-feed-state.json`.
 - On the first non-dry run, the notifier seeds the current backlog into the gist without posting. Use the workflow dispatch input `allow_initial_posts` if you intentionally want to announce the backlog.
 - For a lightweight demo, use the workflow dispatch input `demo_mode`. It posts at most 3 items and seeds the rest of the current backlog so later scheduled runs do not replay the full backlog.

--- a/scripts/community-feed-notifier.mjs
+++ b/scripts/community-feed-notifier.mjs
@@ -8,6 +8,7 @@ import {
   buildDiscordPayload,
   buildMessage,
   defaultState,
+  migrateStateItemIds,
   parseState,
   upsertStateRecord,
 } from "./lib/community-feed-notifier-state.mjs";
@@ -312,6 +313,7 @@ async function main() {
 
   const state = gistId ? await readStateFromGist(gistId, gistToken) : defaultState();
   const now = new Date().toISOString();
+  const migration = migrateStateItemIds(state, memberFeeds);
   const sortedItems = allItems.sort(
     (a, b) => new Date(a.publishedAt).valueOf() - new Date(b.publishedAt).valueOf(),
   );
@@ -343,7 +345,21 @@ async function main() {
   const deliveryFailures = [];
   let limitedItems = 0;
   let processedItems = 0;
-  let stateChanged = false;
+  let stateChanged = migration.changed;
+
+  if (stateChanged) {
+    state.initializedAt = state.initializedAt || now;
+    state.updatedAt = now;
+
+    if (args.dryRun) {
+      console.log(
+        `[notifier] [dry-run] Would migrate ${migration.migratedCount} state item ID(s).`,
+      );
+    } else {
+      await writeStateToGist(gistId, gistToken, state);
+      console.log(`[notifier] Migrated ${migration.migratedCount} state item ID(s).`);
+    }
+  }
 
   for (const item of sortedItems) {
     const record = upsertStateRecord(state, item, now);
@@ -389,6 +405,8 @@ async function main() {
 
   if (!stateChanged) {
     console.log("[notifier] No new community posts needed delivery.");
+  } else if (newDeliveries === 0) {
+    console.log("[notifier] Updated state without sending new deliveries.");
   } else {
     console.log(`[notifier] Sent ${newDeliveries} new delivery(s).`);
   }

--- a/scripts/fetch-feeds.mjs
+++ b/scripts/fetch-feeds.mjs
@@ -372,13 +372,17 @@ async function main() {
       );
 
       feedsWithItems.push({
-        ...source,
+        name: source.name,
+        siteUrl: source.siteUrl,
+        feedUrl: source.feedUrl,
         items: itemsWithLinkedPageImages,
       });
     } catch (error) {
       failures.push({ source: source.name, error: error?.message || String(error) });
       feedsWithItems.push({
-        ...source,
+        name: source.name,
+        siteUrl: source.siteUrl,
+        feedUrl: source.feedUrl,
         items: [],
         error: error?.message || String(error),
       });

--- a/scripts/lib/community-feed-notifier-state.mjs
+++ b/scripts/lib/community-feed-notifier-state.mjs
@@ -1,6 +1,8 @@
+const CURRENT_STATE_VERSION = 2;
+
 export function defaultState() {
   return {
-    version: 1,
+    version: CURRENT_STATE_VERSION,
     initializedAt: null,
     updatedAt: null,
     items: {},
@@ -15,7 +17,7 @@ export function parseState(content) {
   }
 
   return {
-    version: Number(parsed.version) || 1,
+    version: Number(parsed.version) || CURRENT_STATE_VERSION,
     initializedAt:
       typeof parsed.initializedAt === "string" ? parsed.initializedAt : null,
     updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : null,
@@ -26,8 +28,88 @@ export function parseState(content) {
   };
 }
 
+function mergeChannels(targetChannels, sourceChannels) {
+  return {
+    ...(sourceChannels && typeof sourceChannels === "object" ? sourceChannels : {}),
+    ...(targetChannels && typeof targetChannels === "object" ? targetChannels : {}),
+  };
+}
+
+function earliestIsoDate(left, right) {
+  if (!left) return right || null;
+  if (!right) return left;
+  return left < right ? left : right;
+}
+
+function latestIsoDate(left, right) {
+  if (!left) return right || null;
+  if (!right) return left;
+  return left > right ? left : right;
+}
+
+function mergeStateRecords(target, source, id) {
+  return {
+    ...source,
+    ...target,
+    id,
+    firstSeenAt: earliestIsoDate(target?.firstSeenAt, source?.firstSeenAt),
+    lastSeenAt: latestIsoDate(target?.lastSeenAt, source?.lastSeenAt),
+    suppressed: Boolean(target?.suppressed || source?.suppressed),
+    channels: mergeChannels(target?.channels, source?.channels),
+  };
+}
+
+function buildStateItemId(source, sourceItemId) {
+  return `${source.id}::${String(sourceItemId)}`;
+}
+
+function buildLegacyStateItemId(source, sourceItemId) {
+  return `${source.feedUrl}::${String(sourceItemId)}`;
+}
+
+export function migrateStateItemIds(state, sources) {
+  const previousVersion = state.version;
+  const sourceByFeedUrl = new Map(
+    sources
+      .filter((source) => source?.id && source?.feedUrl)
+      .map((source) => [source.feedUrl, source]),
+  );
+  const migratedItems = {};
+  let migratedCount = 0;
+
+  for (const [currentId, record] of Object.entries(state.items)) {
+    const source =
+      record?.source?.feedUrl && sourceByFeedUrl.get(record.source.feedUrl);
+    const sourceItemId = record?.sourceItemId;
+    const nextId =
+      source && sourceItemId ? buildStateItemId(source, sourceItemId) : currentId;
+
+    if (nextId !== currentId) {
+      migratedCount += 1;
+    }
+
+    migratedItems[nextId] = migratedItems[nextId]
+      ? mergeStateRecords(migratedItems[nextId], record, nextId)
+      : {
+          ...record,
+          id: nextId,
+        };
+  }
+
+  state.items = migratedItems;
+  if (migratedCount > 0 || previousVersion !== CURRENT_STATE_VERSION) {
+    state.version = CURRENT_STATE_VERSION;
+  }
+
+  return {
+    changed: migratedCount > 0 || previousVersion !== CURRENT_STATE_VERSION,
+    migratedCount,
+  };
+}
+
 export function upsertStateRecord(state, item, seenAt, options = {}) {
-  const existing = state.items[item.id];
+  const legacyId = buildLegacyStateItemId(item.source, item.sourceItemId);
+  const existing = state.items[item.id] || state.items[legacyId];
   const record = {
     id: item.id,
     sourceItemId: item.sourceItemId,
@@ -49,6 +131,9 @@ export function upsertStateRecord(state, item, seenAt, options = {}) {
   };
 
   state.items[item.id] = record;
+  if (legacyId !== item.id) {
+    delete state.items[legacyId];
+  }
   return record;
 }
 

--- a/scripts/lib/community-feed-reader.mjs
+++ b/scripts/lib/community-feed-reader.mjs
@@ -22,13 +22,14 @@ export async function loadMemberFeeds(filePath = DEFAULT_MEMBER_FEEDS_PATH) {
   }
 
   return parsed.map((item) => {
-    if (!item?.name || !item?.feedUrl || !item?.siteUrl) {
+    if (!item?.id || !item?.name || !item?.feedUrl || !item?.siteUrl) {
       throw new Error(
         `Missing required fields in member feed entry: ${JSON.stringify(item)}`,
       );
     }
 
     return {
+      id: String(item.id),
       name: String(item.name),
       feedUrl: String(item.feedUrl),
       siteUrl: String(item.siteUrl),
@@ -135,6 +136,10 @@ export function parseYoutubeChannelId(html) {
   return null;
 }
 
+function buildNotifierItemId(source, sourceItemId) {
+  return `${source.id}::${String(sourceItemId)}`;
+}
+
 export async function resolveFeedUrl(
   feedUrl,
   {
@@ -184,7 +189,7 @@ export function normalizeNotifierItem(rawItem, source) {
     "";
 
   return {
-    id: `${source.feedUrl}::${String(rawId)}`,
+    id: buildNotifierItemId(source, rawId),
     sourceItemId: String(rawId),
     title: rawItem.title || "Untitled",
     link: rawItem.link || source.siteUrl,

--- a/src/data/member-feeds.json
+++ b/src/data/member-feeds.json
@@ -1,15 +1,18 @@
 [
   {
+    "id": "ash-ryan-arnwine",
     "name": "Ash Ryan Arnwine",
     "siteUrl": "https://www.ashryan.io/",
     "feedUrl": "https://www.ashryan.io/rss/"
   },
   {
+    "id": "ashwin-anil",
     "name": "Ashwin Anil",
     "siteUrl": "https://ashwin.im/",
     "feedUrl": "https://ashwin.im/rss.xml"
   },
   {
+    "id": "mere-mortal-dev",
     "name": "Mere Mortal Dev",
     "siteUrl": "https://www.youtube.com/@meremortaldev",
     "feedUrl": "https://www.youtube.com/@meremortaldev"

--- a/test/community-feed-notifier-state.test.mjs
+++ b/test/community-feed-notifier-state.test.mjs
@@ -3,19 +3,21 @@ import {
   buildDiscordPayload,
   buildMessage,
   defaultState,
+  migrateStateItemIds,
   parseState,
   upsertStateRecord,
 } from "../scripts/lib/community-feed-notifier-state.mjs";
 
 function sampleItem(overrides = {}) {
   return {
-    id: "https://example.com/feed.xml::post-1",
+    id: "example-author::post-1",
     sourceItemId: "post-1",
     title: "Post One",
     link: "https://example.com/post-1",
     publishedAt: "2026-04-25T05:35:48.687Z",
     summary: "A useful post",
     source: {
+      id: "example-author",
       name: "Example Author",
       feedUrl: "https://example.com/feed.xml",
       siteUrl: "https://example.com/",
@@ -26,7 +28,7 @@ function sampleItem(overrides = {}) {
 
 test("defaultState creates an empty notifier state", () => {
   expect(defaultState()).toEqual({
-    version: 1,
+    version: 2,
     initializedAt: null,
     updatedAt: null,
     items: {},
@@ -62,7 +64,7 @@ test("upsertStateRecord inserts a new item with suppression and channel defaults
   );
 
   expect(record).toMatchObject({
-    id: "https://example.com/feed.xml::post-1",
+    id: "example-author::post-1",
     sourceItemId: "post-1",
     firstSeenAt: "2026-04-25T06:00:00.000Z",
     lastSeenAt: "2026-04-25T06:00:00.000Z",
@@ -103,6 +105,90 @@ test("upsertStateRecord preserves firstSeenAt, suppression, and delivery channel
   expect(record.suppressed).toBe(false);
   expect(record.channels.discord.deliveredAt).toBe("2026-04-24T00:01:00.000Z");
   expect(record.title).toBe("Updated title");
+});
+
+test("upsertStateRecord migrates a legacy item key while preserving history", () => {
+  const item = sampleItem();
+  const legacyId = "https://example.com/feed.xml::post-1";
+  const state = {
+    ...defaultState(),
+    items: {
+      [legacyId]: {
+        ...item,
+        id: legacyId,
+        firstSeenAt: "2026-04-24T00:00:00.000Z",
+        lastSeenAt: "2026-04-24T00:00:00.000Z",
+        suppressed: true,
+        channels: {
+          discord: {
+            deliveredAt: "2026-04-24T00:01:00.000Z",
+          },
+        },
+      },
+    },
+  };
+
+  const record = upsertStateRecord(
+    state,
+    item,
+    "2026-04-25T06:00:00.000Z",
+  );
+
+  expect(record.id).toBe("example-author::post-1");
+  expect(record.firstSeenAt).toBe("2026-04-24T00:00:00.000Z");
+  expect(record.suppressed).toBe(true);
+  expect(record.channels.discord.deliveredAt).toBe("2026-04-24T00:01:00.000Z");
+  expect(state.items[legacyId]).toBeUndefined();
+  expect(state.items[item.id]).toBe(record);
+});
+
+test("migrateStateItemIds converts legacy gist keys to source-stable keys", () => {
+  const legacyId = "https://example.com/feed.xml::post-1";
+  const state = {
+    version: 1,
+    initializedAt: "2026-04-24T00:00:00.000Z",
+    updatedAt: "2026-04-24T00:00:00.000Z",
+    items: {
+      [legacyId]: {
+        ...sampleItem({ id: legacyId }),
+        firstSeenAt: "2026-04-24T00:00:00.000Z",
+        lastSeenAt: "2026-04-24T00:00:00.000Z",
+        suppressed: true,
+        channels: {
+          discord: {
+            deliveredAt: "2026-04-24T00:01:00.000Z",
+          },
+        },
+      },
+    },
+  };
+
+  const result = migrateStateItemIds(state, [
+    {
+      id: "example-author",
+      name: "Example Author",
+      feedUrl: "https://example.com/feed.xml",
+      siteUrl: "https://example.com/",
+    },
+  ]);
+
+  expect(result).toEqual({
+    changed: true,
+    migratedCount: 1,
+  });
+  expect(state.version).toBe(2);
+  expect(state.items[legacyId]).toBeUndefined();
+  expect(state.items["example-author::post-1"]).toMatchObject({
+    id: "example-author::post-1",
+    firstSeenAt: "2026-04-24T00:00:00.000Z",
+    lastSeenAt: "2026-04-24T00:00:00.000Z",
+    suppressed: true,
+    channels: {
+      discord: {
+        deliveredAt: "2026-04-24T00:01:00.000Z",
+      },
+    },
+  });
 });
 
 test("buildMessage formats a plain text destination message", () => {

--- a/test/community-feed-reader.test.mjs
+++ b/test/community-feed-reader.test.mjs
@@ -20,6 +20,7 @@ test("loadMemberFeeds normalizes valid source entries", async () => {
     filePath,
     JSON.stringify([
       {
+        id: "example-author",
         name: "Example Author",
         feedUrl: "https://example.com/feed.xml",
         siteUrl: "https://example.com/",
@@ -29,6 +30,7 @@ test("loadMemberFeeds normalizes valid source entries", async () => {
 
   await expect(loadMemberFeeds(filePath)).resolves.toEqual([
     {
+      id: "example-author",
       name: "Example Author",
       feedUrl: "https://example.com/feed.xml",
       siteUrl: "https://example.com/",
@@ -84,8 +86,9 @@ test("parseYoutubeChannelId supports common channel id locations", () => {
   expect(parseYoutubeChannelId("no channel here")).toBeNull();
 });
 
-test("normalizeNotifierItem preserves notifier item identity format", () => {
+test("normalizeNotifierItem uses source-stable notifier item IDs", () => {
   const source = {
+    id: "example-author",
     name: "Example Author",
     feedUrl: "https://example.com/feed.xml",
     siteUrl: "https://example.com/",
@@ -101,7 +104,7 @@ test("normalizeNotifierItem preserves notifier item identity format", () => {
     source,
   );
 
-  expect(item.id).toBe("https://example.com/feed.xml::post-1");
+  expect(item.id).toBe("example-author::post-1");
   expect(item.sourceItemId).toBe("post-1");
   expect(item.summary).toBe("A useful post");
   expect(item.source).toEqual(source);
@@ -109,6 +112,7 @@ test("normalizeNotifierItem preserves notifier item identity format", () => {
 
 test("fetchFeedItems fetches, normalizes, dedupes, sorts, and limits items", async () => {
   const source = {
+    id: "example-author",
     name: "Example Author",
     feedUrl: "https://example.com/feed.xml",
     siteUrl: "https://example.com/",


### PR DESCRIPTION
## Summary
- Add durable source IDs to `member-feeds.json` and use them for notifier item IDs.
- Migrate gist-backed notifier state from legacy `feedUrl::sourceItemId` keys to `sourceId::sourceItemId` keys.
- Preserve suppression, first/last seen timestamps, and delivery channel history during migration.
- Keep generated composite feed output shape unchanged by omitting the internal source ID from site feed JSON.

## Validation
- `npm run test`
- `env COMMUNITY_FEED_STATE_GIST_ID=f95dd7597eec170d738d905e3666bfc6 npm run feeds:notify:dry-run`
- `node scripts/community-feed-notifier.mjs --skip-without-destinations`
- `npm run feeds:pull -- --output /tmp/kyoto-tech/composite-feed-id-migration-test.json`
- `npm run check`
- `git diff --check`

## Migration note
The live gist dry-run reports that 28 existing state records would migrate, with no new deliveries. The first non-dry run after merge will write the migrated state and should not repost the old backlog.