### PR TITLE
Fix locale routing and responsive navigation

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,8 +19,7 @@ const contactUrl = "https://forms.gle/NPtc1G1vM9jGBYhp6";
 <footer class="bg-stone-950 px-6 py-12 text-slate-100 md:px-12">
 	<div class="mx-auto flex max-w-5xl flex-col gap-6 md:flex-row md:items-center md:justify-between">
 		<p class="text-sm text-slate-300">
-			© 2025–{new Date().getFullYear()}
-			{t("home.footer.copyright")}
+			© 2025–{new Date().getFullYear()} {t("home.footer.copyright")}
 		</p>
 		<nav aria-label={t("home.footer.socialNavLabel")}>
 			<ul class="flex flex-wrap gap-4 text-sm font-medium text-slate-200">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import LanguagePicker from "./LanguagePicker.astro";
 import { useTranslations } from "../i18n/utils";
+import { getLocalizedHomePath, getLocalizedSectionPath } from "../i18n/navigation";
 
 type Props = {
   lang?: "en" | "ja";
@@ -9,32 +10,134 @@ type Props = {
 const { lang = "en" } = Astro.props as Props;
 const t = useTranslations(lang);
 
-const homeUrl = lang === "ja" ? "/ja/" : "/";
-const calendarUrl = `${homeUrl}#calendar`;
+const homeUrl = getLocalizedHomePath(lang);
+const calendarUrl = getLocalizedSectionPath(lang, "calendar");
+const locationsUrl = getLocalizedSectionPath(lang, "locations");
+const communityHubUrl = getLocalizedSectionPath(lang, "community-hub");
+const mobileMenuId = `site-navigation-menu-${lang}`;
+
+const navItems = [
+  { href: calendarUrl, label: t("nav.calendar") },
+  { href: locationsUrl, label: t("nav.locations") },
+  { href: communityHubUrl, label: t("nav.communityHub") },
+];
 ---
 
-<nav class="fixed top-0 left-0 right-0 z-50 px-4 py-4">
-  <div class="mx-auto flex max-w-6xl items-center justify-between rounded-full border border-slate-100 bg-white px-4 py-2 shadow-lg shadow-black/5">
-    <div class="flex items-center gap-6">
-      <a href={homeUrl} class="flex items-center gap-2" aria-label={t("home.header.tagline")}>
-        <span class="font-medium text-slate-900">
-          {t("home.header.tagline")}
-        </span>
-      </a>
-      <div class="hidden items-center gap-1 md:flex">
-        <a href={`${homeUrl}#why-join`} class="rounded-full px-3 py-1 text-sm text-slate-600 transition hover:text-slate-900">{t("nav.about")}</a>
-        <a href={`${homeUrl}#calendar`} class="rounded-full px-3 py-1 text-sm text-slate-600 transition hover:text-slate-900">{t("nav.events")}</a>
-        <a href={`${homeUrl}#community-feed`} class="rounded-full px-3 py-1 text-sm text-slate-600 transition hover:text-slate-900">{t("nav.communityFeed")}</a>
+<nav
+  class="fixed top-0 left-0 right-0 z-50 px-3 py-3 sm:px-4 sm:py-4"
+  aria-label={t("a11y.primaryNav")}
+  data-site-navigation
+>
+  <div class="relative mx-auto max-w-6xl">
+    <div class="flex items-center justify-between rounded-full border border-slate-100 bg-white px-3 py-2 shadow-lg shadow-black/5 sm:px-4">
+      <div class="flex min-w-0 items-center gap-5 lg:gap-6">
+        <a
+          href={homeUrl}
+          class="flex shrink-0 items-center gap-2 rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-slate-700"
+          aria-label={t("home.header.tagline")}
+        >
+          <span class="font-medium text-slate-900 sm:hidden">Kyoto Tech</span>
+          <span class="hidden font-medium text-slate-900 sm:inline">
+            {t("home.header.tagline")}
+          </span>
+        </a>
+        <div class="hidden items-center gap-1 lg:flex">
+          {navItems.map((item) => (
+            <a
+              href={item.href}
+              class="rounded-full px-2.5 py-1 text-sm text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700 lg:px-3"
+            >
+              {item.label}
+            </a>
+          ))}
+        </div>
+      </div>
+
+      <div class="flex shrink-0 items-center gap-2 sm:gap-3">
+        <LanguagePicker lang={lang} />
+        <a
+          href={calendarUrl}
+          class="rounded-full bg-slate-900 px-4 py-2 text-sm text-white transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700 sm:px-5"
+        >
+          <span class="sm:hidden">{t("nav.eventsShort")}</span>
+          <span class="hidden sm:inline">{t("nav.nextMeetup")}</span>
+        </a>
+        <button
+          type="button"
+          class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 text-slate-700 transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700 lg:hidden"
+          aria-controls={mobileMenuId}
+          aria-expanded="false"
+          aria-label={t("a11y.openMenu")}
+          data-open-label={t("a11y.openMenu")}
+          data-close-label={t("a11y.closeMenu")}
+          data-menu-button
+        >
+          <svg data-menu-open-icon aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <path d="M4 7h16M4 12h16M4 17h16"></path>
+          </svg>
+          <svg data-menu-close-icon aria-hidden="true" viewBox="0 0 24 24" class="hidden h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <path d="m6 6 12 12M18 6 6 18"></path>
+          </svg>
+        </button>
       </div>
     </div>
-    <div class="flex items-center gap-3">
-      <LanguagePicker />
-      <a
-        href={calendarUrl}
-        class="rounded-full bg-slate-900 px-5 py-2 text-sm text-white transition hover:bg-slate-800"
-      >
-        {t("home.header.cta")}
-      </a>
+
+    <div
+      id={mobileMenuId}
+      hidden
+      class="absolute right-0 left-0 top-[calc(100%+0.5rem)] rounded-2xl border border-slate-200 bg-white p-3 shadow-xl shadow-black/10 lg:hidden"
+      data-menu-panel
+    >
+      <div class="grid gap-1">
+        {navItems.map((item) => (
+          <a
+            href={item.href}
+            class="inline-flex min-h-11 items-center rounded-xl px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 hover:text-slate-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700"
+          >
+            {item.label}
+          </a>
+        ))}
+      </div>
+      <div class="mt-3 border-t border-slate-100 pt-3">
+        <LanguagePicker lang={lang} variant="mobile" />
+      </div>
     </div>
   </div>
 </nav>
+
+<script is:inline data-astro-rerun>
+  {
+    const siteNavigation = document.querySelector("[data-site-navigation]");
+    const menuButton = siteNavigation?.querySelector("[data-menu-button]");
+    const menuPanel = siteNavigation?.querySelector("[data-menu-panel]");
+    const openIcon = menuButton?.querySelector("[data-menu-open-icon]");
+    const closeIcon = menuButton?.querySelector("[data-menu-close-icon]");
+
+    if (siteNavigation && menuButton instanceof HTMLButtonElement && menuPanel instanceof HTMLElement) {
+      const setMenuOpen = (open) => {
+        menuButton.setAttribute("aria-expanded", String(open));
+        menuButton.setAttribute(
+          "aria-label",
+          open ? menuButton.dataset.closeLabel : menuButton.dataset.openLabel,
+        );
+        menuPanel.hidden = !open;
+        if (openIcon instanceof SVGElement) openIcon.classList.toggle("hidden", open);
+        if (closeIcon instanceof SVGElement) closeIcon.classList.toggle("hidden", !open);
+      };
+
+      menuButton.addEventListener("click", () => {
+        setMenuOpen(menuButton.getAttribute("aria-expanded") !== "true");
+      });
+
+      menuPanel.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", () => setMenuOpen(false));
+      });
+
+      siteNavigation.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape" || menuButton.getAttribute("aria-expanded") !== "true") return;
+        setMenuOpen(false);
+        menuButton.focus();
+      });
+    }
+  }
+</script>

--- a/src/components/LanguagePicker.astro
+++ b/src/components/LanguagePicker.astro
@@ -1,14 +1,30 @@
 ---
-import { languages } from "../i18n/ui";
+import { defaultLang, languages } from "../i18n/ui";
 import { useTranslations } from "../i18n/utils";
 import { getRelativeLocaleUrl } from "astro:i18n";
 
-const activeLang = Astro.currentLocale as "en" | "ja" | undefined;
-const t = useTranslations(activeLang ?? "en");
+type Props = {
+	lang?: keyof typeof languages;
+	variant?: "desktop" | "mobile";
+};
+
+const {
+	lang = (Astro.currentLocale as keyof typeof languages | undefined) ?? defaultLang,
+	variant = "desktop",
+} = Astro.props as Props;
+const activeLang = lang;
+const t = useTranslations(activeLang);
 const allLangs = Object.entries(languages) as [keyof typeof languages, string][];
 
 ---
-<div class="hidden items-center rounded-full bg-slate-50 p-1 shadow-sm sm:inline-flex">
+<div
+	class:list={[
+		"items-center bg-slate-50 p-1 shadow-sm",
+		variant === "desktop"
+			? "hidden rounded-full lg:inline-flex"
+			: "grid grid-cols-2 gap-1 rounded-xl",
+	]}
+>
 	{allLangs.map(([lang, label]) => {
 		const isActive = lang === activeLang;
 
@@ -17,7 +33,10 @@ const allLangs = Object.entries(languages) as [keyof typeof languages, string][]
 				href={getRelativeLocaleUrl(lang, "/")}
 				data-language={lang}
 				class:list={[
-					"rounded-full px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700",
+					"rounded-full text-center text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700",
+					variant === "desktop"
+						? "px-3 py-1"
+						: "inline-flex min-h-11 items-center justify-center px-4 py-2",
 					isActive
 						? "border border-slate-200 bg-white text-slate-900 shadow"
 						: "text-slate-600 hover:text-slate-900",
@@ -31,21 +50,3 @@ const allLangs = Object.entries(languages) as [keyof typeof languages, string][]
 		);
 	})}
 </div>
-
-<script is:inline>
-	const LANGUAGE_STORAGE_KEY = "kyoto-tech-language";
-	const languageLinks = document.querySelectorAll("a[data-language]");
-
-	languageLinks.forEach((link) => {
-		link.addEventListener("click", () => {
-			const selectedLanguage = link.getAttribute("data-language");
-			if (selectedLanguage !== "en" && selectedLanguage !== "ja") return;
-
-			try {
-				localStorage.setItem(LANGUAGE_STORAGE_KEY, selectedLanguage);
-			} catch {
-				// Ignore if storage is unavailable.
-			}
-		});
-	});
-</script>

--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -1,0 +1,14 @@
+type SiteLanguage = "en" | "ja";
+
+type HomeSection = "calendar" | "community-hub" | "locations";
+
+export function getLocalizedHomePath(lang: SiteLanguage): "/" | "/ja/" {
+  return lang === "ja" ? "/ja/" : "/";
+}
+
+export function getLocalizedSectionPath(
+  lang: SiteLanguage,
+  section: HomeSection,
+): string {
+  return `${getLocalizedHomePath(lang)}#${section}`;
+}

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -1,6 +1,6 @@
 export const languages = {
   en: "English",
-  ja: "Japanese",
+  ja: "日本語",
 };
 
 export const defaultLang = "en";
@@ -9,6 +9,9 @@ export const ui = {
   en: {
     "a11y.skipToMain": "Skip to main content",
     "a11y.switchLang": "Switch language to {label}",
+    "a11y.primaryNav": "Primary navigation",
+    "a11y.openMenu": "Open navigation menu",
+    "a11y.closeMenu": "Close navigation menu",
     "a11y.mapTitle": "Map of {name}",
     "a11y.mapLabel": "Embedded map showing the location of {name}",
 
@@ -21,9 +24,11 @@ export const ui = {
     "home.header.cta": "Join Us",
     "home.header.discordCta": "Join our Discord",
     "home.header.githubCta": "View our GitHub",
-    "nav.about": "About Us",
-    "nav.events": "Events",
-    "nav.communityFeed": "Community Feed",
+    "nav.nextMeetup": "Next meetup",
+    "nav.eventsShort": "Events",
+    "nav.calendar": "Calendar",
+    "nav.locations": "Locations",
+    "nav.communityHub": "Community Hub",
 
     "home.quickLinks.title": "Connect with the community",
     "home.quickLinks.meetup.title": "Meetup",
@@ -119,6 +124,9 @@ export const ui = {
   ja: {
     "a11y.skipToMain": "メインコンテンツへスキップ",
     "a11y.switchLang": "{label}に言語を切り替える",
+    "a11y.primaryNav": "メインナビゲーション",
+    "a11y.openMenu": "ナビゲーションメニューを開く",
+    "a11y.closeMenu": "ナビゲーションメニューを閉じる",
     "a11y.mapTitle": "{name}の地図",
     "a11y.mapLabel": "{name}の場所を示す埋め込み地図",
 
@@ -131,9 +139,11 @@ export const ui = {
     "home.header.cta": "参加する",
     "home.header.discordCta": "Discordでチャットする",
     "home.header.githubCta": "GitHubでコードを見る",
-    "nav.about": "私たちについて",
-    "nav.events": "イベント",
-    "nav.communityFeed": "コミュニティフィード",
+    "nav.nextMeetup": "次回のイベント",
+    "nav.eventsShort": "イベント",
+    "nav.calendar": "カレンダー",
+    "nav.locations": "開催場所",
+    "nav.communityHub": "コミュニティハブ",
 
     "home.quickLinks.title": "コミュニティとつながる",
     "home.quickLinks.meetup.title": "Meetup",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -133,9 +133,6 @@ const ldData = {
 	]
 };
 
-const enHomePath = getRelativeLocaleUrl("en", "/");
-const jaHomePath = getRelativeLocaleUrl("ja", "/");
-
 ---
 
 <!doctype html>
@@ -186,45 +183,6 @@ const jaHomePath = getRelativeLocaleUrl("ja", "/");
 		<link rel="canonical" href={canonicalUrl} />
 		<script type="application/ld+json" is:inline set:html={JSON.stringify(ldData)}></script>
 		<title>{t("meta.title")}</title>
-			<script is:inline define:vars={{ enHomePath, jaHomePath }}>
-				const LANGUAGE_STORAGE_KEY = "kyoto-tech-language";
-
-				const normalizePath = (value) => {
-					const withoutIndex = value.replace(/index\.html$/, "");
-					return withoutIndex.endsWith("/") ? withoutIndex : `${withoutIndex}/`;
-				};
-
-				const currentPath = normalizePath(location.pathname);
-				const normalizedEnHomePath = normalizePath(enHomePath);
-				const normalizedJaHomePath = normalizePath(jaHomePath);
-
-				const isOnEnglishHome = currentPath === normalizedEnHomePath;
-				const isOnJapaneseHome = currentPath === normalizedJaHomePath;
-
-				let preferredLanguage = null;
-				try {
-					preferredLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
-				} catch {
-					preferredLanguage = null;
-				}
-
-				const browserPrefersJapanese =
-					(navigator.language?.toLowerCase().startsWith("ja")) ||
-					(navigator.languages?.some((lang) => lang.toLowerCase().startsWith("ja")));
-
-				const targetLanguage =
-					preferredLanguage === "en" || preferredLanguage === "ja"
-						? preferredLanguage
-						: browserPrefersJapanese
-							? "ja"
-							: "en";
-
-				if (isOnEnglishHome && targetLanguage === "ja") {
-					location.replace(normalizedJaHomePath);
-				} else if (isOnJapaneseHome && targetLanguage === "en") {
-					location.replace(normalizedEnHomePath);
-				}
-			</script>
 			<ClientRouter />
 	</head>
 	<body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -160,7 +160,7 @@ const formatDate = (value: string) => {
   </div>
 
   <main id="main-content" class="space-y-0">
-    <section id="quick-links" class="bg-white/90 px-6 py-12 md:px-12">
+    <section id="community-hub" class="scroll-mt-24 bg-white/90 px-6 py-12 md:px-12">
       <div class="mx-auto max-w-5xl">
         <h2 class="text-3xl font-semibold text-slate-900">
           {t("home.quickLinks.title")}
@@ -242,7 +242,7 @@ const formatDate = (value: string) => {
           nextLabel={t("home.communityFeed.nextUpdate")}
         />
 
-        <div id="locations" class="mt-12">
+        <div id="locations" class="mt-12 scroll-mt-24">
           <h3 class="text-2xl font-semibold text-slate-900">
             {t("home.locations.title")}
           </h3>

--- a/test/i18n-navigation.test.mjs
+++ b/test/i18n-navigation.test.mjs
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { ui } from "../src/i18n/ui.ts";
+import {
+  getLocalizedHomePath,
+  getLocalizedSectionPath,
+} from "../src/i18n/navigation.ts";
+
+describe("localized navigation", () => {
+  it("keeps the English and Japanese translation tables aligned", () => {
+    expect(Object.keys(ui.ja).sort()).toEqual(Object.keys(ui.en).sort());
+  });
+
+  it("returns explicit locale home paths", () => {
+    expect(getLocalizedHomePath("en")).toBe("/");
+    expect(getLocalizedHomePath("ja")).toBe("/ja/");
+  });
+
+  it("builds localized section links", () => {
+    expect(getLocalizedSectionPath("en", "calendar")).toBe("/#calendar");
+    expect(getLocalizedSectionPath("ja", "locations")).toBe(
+      "/ja/#locations",
+    );
+    expect(getLocalizedSectionPath("ja", "community-hub")).toBe(
+      "/ja/#community-hub",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- respect explicit locale URLs by removing the client-side language redirect that could override `/ja/`
- replace the desktop-only language picker with responsive, localized navigation and a keyboard-accessible mobile menu
- add task-oriented Calendar, Locations, and Community Hub destinations with fixed-header anchor offsets
- keep English and Japanese navigation keys aligned and fix the footer copyright spacing
- add focused tests for localized paths and translation-table parity

## Why

The previous startup script treated browser or stored language preference as more authoritative than the URL, so an explicit Japanese visit could redirect to English. The language picker and section navigation were also unavailable on mobile. This establishes the locale and navigation foundation needed by the homepage redesign.

## User impact

Visitors can now trust explicit English and Japanese URLs, switch languages at every supported viewport, and reach core resources from a responsive navigation menu. Tablet layouts use the compact menu to avoid wrapped Japanese labels.

## Validation

- `npm run check` — lint, TypeScript, Knip, 71 tests, Astro diagnostics, and image checks pass
- `npm run build` — both `/` and `/ja/` build successfully
- production-preview verification at 320px, 768px, and 1024px
- verified localized metadata, no horizontal overflow, menu open/close and Escape focus restoration, locale switching across Astro transitions, and fixed-header anchor offsets
