### PR TITLE
Use presentation photo in hero

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -170,7 +170,7 @@ const formatDate = (value: string) => {
       fallbackCtaLabel={t("home.hero.fallbackCta")}
       fallbackUrl={meetupUrl}
       imageAlt={t("home.hero.imageAlt")}
-      imageSrc="/images/kyoto-tech-community-work-session.jpg"
+      imageSrc="/images/kyoto-tech-community-presentation.jpeg"
       lang={lang}
       now={buildNow}
       primaryCtaLabel={t("home.hero.primaryCta")}


### PR DESCRIPTION
## What changed

- Switch the hero background from the work-session photo to the approved presentation photo.
- Keep the lighter contrast treatment from the merged hero redesign unchanged.

## Why

The presentation image is the intended hero artwork and is the version reviewed during the final contrast pass.

## Validation

- npm run check (92 tests)
- npx astro build
- English desktop verification at 1440px
- English mobile verification at 390px
- Confirmed no page-level horizontal overflow