### PR TITLE
Add Daniel Kishimoto member feed

### DIFF
--- a/scripts/fetch-feeds.mjs
+++ b/scripts/fetch-feeds.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import Parser from "rss-parser";
 import {
   fetchRawFeedItems,
@@ -49,30 +50,100 @@ function parseArgs(argv) {
   return args;
 }
 
-function extractMediaUrl(value) {
+const IMAGE_FILE_EXTENSIONS = new Set([
+  ".avif",
+  ".gif",
+  ".jpeg",
+  ".jpg",
+  ".png",
+  ".svg",
+  ".webp",
+]);
+const NON_IMAGE_FILE_EXTENSIONS = new Set([
+  ".m4v",
+  ".mov",
+  ".mp3",
+  ".mp4",
+  ".mpeg",
+  ".mpg",
+  ".ogg",
+  ".ogv",
+  ".wav",
+  ".webm",
+]);
+
+function extractMediaCandidate(value) {
   if (!value) return null;
   if (typeof value === "string") {
-    return value.startsWith("http") ? value : null;
+    return value.startsWith("http") ? { url: value } : null;
   }
   if (Array.isArray(value)) {
     for (const entry of value) {
-      const url = extractMediaUrl(entry);
-      if (url) return url;
+      const candidate = extractMediaCandidate(entry);
+      if (candidate) return candidate;
     }
     return null;
   }
   if (typeof value === "object") {
-    if (typeof value.url === "string" && value.url.startsWith("http")) {
-      return value.url;
-    }
-    if (typeof value.href === "string" && value.href.startsWith("http")) {
-      return value.href;
-    }
-    if (typeof value.$?.url === "string" && value.$.url.startsWith("http")) {
-      return value.$.url;
-    }
+    const url = value.url ?? value.href ?? value.$?.url;
+    if (typeof url !== "string" || !url.startsWith("http")) return null;
+
+    return {
+      url,
+      type: value.type ?? value.$?.type ?? null,
+      medium: value.medium ?? value.$?.medium ?? null,
+    };
   }
   return null;
+}
+
+function getUrlExtension(rawUrl) {
+  try {
+    return path.extname(new URL(rawUrl).pathname).toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+export function isImageMediaCandidate(
+  candidate,
+  { semanticImage = false } = {},
+) {
+  if (!candidate?.url || typeof candidate.url !== "string") return false;
+
+  const mimeType = String(candidate.type ?? "")
+    .split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+  const medium = String(candidate.medium ?? "").trim().toLowerCase();
+  const extension = getUrlExtension(candidate.url);
+
+  if (mimeType.startsWith("image/")) return true;
+  if (
+    mimeType.startsWith("video/") ||
+    mimeType.startsWith("audio/") ||
+    medium === "video" ||
+    medium === "audio" ||
+    NON_IMAGE_FILE_EXTENSIONS.has(extension)
+  ) {
+    return false;
+  }
+
+  if (IMAGE_FILE_EXTENSIONS.has(extension)) return true;
+  return semanticImage;
+}
+
+function findImageMediaUrl(value, options = {}) {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const imageUrl = findImageMediaUrl(entry, options);
+      if (imageUrl) return imageUrl;
+    }
+    return null;
+  }
+
+  const candidate = extractMediaCandidate(value);
+  return isImageMediaCandidate(candidate, options) ? candidate.url : null;
 }
 
 function toHtmlString(value) {
@@ -144,6 +215,32 @@ function getHtmlAttribute(tag, attribute) {
   return unquoted?.[1] || null;
 }
 
+function extractImageFromTag(tag, baseUrl) {
+  const source =
+    getHtmlAttribute(tag, "src") || getHtmlAttribute(tag, "data-src");
+  const sourceUrl = resolveImageUrl(source, baseUrl);
+  if (sourceUrl) return sourceUrl;
+
+  const srcset = getHtmlAttribute(tag, "srcset");
+  const firstCandidate = srcset?.split(",")[0]?.trim().split(/\s+/)[0];
+  return resolveImageUrl(firstCandidate, baseUrl);
+}
+
+function extractWordpressFeaturedImage(html, baseUrl) {
+  if (!html || typeof html !== "string") return null;
+
+  const imageTags = html.match(/<img\b[^>]*>/gi) || [];
+  for (const imageTag of imageTags) {
+    const className = getHtmlAttribute(imageTag, "class") || "";
+    if (!className.split(/\s+/).includes("wp-post-image")) continue;
+
+    const imageUrl = extractImageFromTag(imageTag, baseUrl);
+    if (imageUrl) return imageUrl;
+  }
+
+  return null;
+}
+
 function extractMetaImageFromHtml(html, baseUrl) {
   if (!html || typeof html !== "string") return null;
 
@@ -169,16 +266,22 @@ function extractMetaImageFromHtml(html, baseUrl) {
       itemProp === "image"
     ) {
       const imageUrl = resolveImageUrl(content, baseUrl);
-      if (imageUrl) return imageUrl;
+      if (
+        imageUrl &&
+        isImageMediaCandidate({ url: imageUrl }, { semanticImage: true })
+      ) {
+        return imageUrl;
+      }
     }
   }
 
   return null;
 }
 
-function extractPageImage(html, pageUrl) {
+export function extractPageImage(html, pageUrl) {
   return (
     extractMetaImageFromHtml(html, pageUrl) ||
+    extractWordpressFeaturedImage(html, pageUrl) ||
     extractFirstImageFromHtml(html, pageUrl)
   );
 }
@@ -233,29 +336,51 @@ function extractYoutubeVideoId(rawItem) {
   return null;
 }
 
-function resolveImage(rawItem, source) {
+export function resolveFeedImage(rawItem, source) {
+  const enclosureUrl = findImageMediaUrl(rawItem.enclosure);
+  if (enclosureUrl) return enclosureUrl;
+
+  const mediaCandidates = [
+    { value: rawItem["media:thumbnail"], semanticImage: true },
+    { value: rawItem.mediaThumbnail, semanticImage: true },
+    {
+      value: rawItem["media:group"]?.["media:thumbnail"],
+      semanticImage: true,
+    },
+    {
+      value: rawItem["media_group"]?.["media:thumbnail"],
+      semanticImage: true,
+    },
+    { value: rawItem["media:content"], semanticImage: false },
+    {
+      value: rawItem["media:group"]?.["media:content"],
+      semanticImage: false,
+    },
+    {
+      value: rawItem["media_group"]?.["media:content"],
+      semanticImage: false,
+    },
+  ];
+  for (const { value, semanticImage } of mediaCandidates) {
+    const mediaUrl = findImageMediaUrl(value, { semanticImage });
+    if (mediaUrl) return mediaUrl;
+  }
+
+  if (isYoutubeUrl(source?.feedUrl) || isYoutubeUrl(source?.siteUrl)) {
+    const videoId = extractYoutubeVideoId(rawItem);
+    if (videoId) {
+      return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+    }
+  }
+
+  return null;
+}
+
+function resolveInlineContentImage(rawItem, source) {
   const baseUrl =
     (typeof rawItem.link === "string" && rawItem.link) ||
     (typeof source?.siteUrl === "string" && source.siteUrl) ||
     null;
-
-  const enclosureUrl =
-    typeof rawItem.enclosure?.url === "string" ? rawItem.enclosure.url : null;
-  if (enclosureUrl?.startsWith("http")) return enclosureUrl;
-
-  const mediaUrlCandidates = [
-    rawItem["media:thumbnail"],
-    rawItem.mediaThumbnail,
-    rawItem["media:content"],
-    rawItem["media:group"]?.["media:thumbnail"],
-    rawItem["media:group"]?.["media:content"],
-    rawItem["media_group"]?.["media:thumbnail"],
-    rawItem["media_group"]?.["media:content"],
-  ];
-  for (const candidate of mediaUrlCandidates) {
-    const mediaUrl = extractMediaUrl(candidate);
-    if (mediaUrl?.startsWith("http")) return mediaUrl;
-  }
 
   const htmlCandidates = [
     rawItem["content:encoded"],
@@ -269,13 +394,6 @@ function resolveImage(rawItem, source) {
   for (const candidate of htmlCandidates) {
     const inlineImage = extractFirstImageFromHtml(candidate, baseUrl);
     if (inlineImage) return inlineImage;
-  }
-
-  if (isYoutubeUrl(source?.feedUrl) || isYoutubeUrl(source?.siteUrl)) {
-    const videoId = extractYoutubeVideoId(rawItem);
-    if (videoId) {
-      return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
-    }
   }
 
   return null;
@@ -308,26 +426,39 @@ function normalizeItem(rawItem, source) {
       feedUrl: source.feedUrl,
     },
     summary: truncate(summary, 360),
-    image: resolveImage(rawItem, source),
+    image: resolveFeedImage(rawItem, source),
+    inlineImage: resolveInlineContentImage(rawItem, source),
   };
 }
 
-async function enrichItemWithLinkedPageImage(item) {
-  if (item?.image || typeof item?.link !== "string") return item;
-  if (!item.link.startsWith("http://") && !item.link.startsWith("https://")) {
-    return item;
+export async function enrichItemWithLinkedPageImage(
+  item,
+  { fetchTextFn = fetchText } = {},
+) {
+  const { inlineImage, ...publicItem } = item;
+  if (publicItem.image) return publicItem;
+  if (
+    typeof publicItem.link !== "string" ||
+    (!publicItem.link.startsWith("http://") &&
+      !publicItem.link.startsWith("https://"))
+  ) {
+    return { ...publicItem, image: inlineImage ?? null };
   }
 
   try {
-    const html = await fetchText(item.link, {}, ITEM_PAGE_TIMEOUT_MS, USER_AGENT);
-    const image = extractPageImage(html, item.link);
-    if (!image) return item;
+    const html = await fetchTextFn(
+      publicItem.link,
+      {},
+      ITEM_PAGE_TIMEOUT_MS,
+      USER_AGENT,
+    );
+    const image = extractPageImage(html, publicItem.link);
     return {
-      ...item,
-      image,
+      ...publicItem,
+      image: image ?? inlineImage ?? null,
     };
   } catch {
-    return item;
+    return { ...publicItem, image: inlineImage ?? null };
   }
 }
 
@@ -429,7 +560,13 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error("[feeds] Unhandled error:", error);
-  process.exit(1);
-});
+const isMainModule =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error("[feeds] Unhandled error:", error);
+    process.exit(1);
+  });
+}

--- a/src/data/composite-feed.json
+++ b/src/data/composite-feed.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T16:44:37.381Z",
+  "generatedAt": "2026-07-10T02:47:58.518Z",
   "itemsPerFeed": 3,
   "feeds": [
     {
@@ -7,6 +7,19 @@
       "siteUrl": "https://www.ashryan.io/",
       "feedUrl": "https://www.ashryan.io/rss/",
       "items": [
+        {
+          "id": "https://www.ashryan.io/writing/the-human-touch-still-matters-for-api-platforms/",
+          "title": "The human touch still matters for API platforms",
+          "link": "https://www.ashryan.io/writing/the-human-touch-still-matters-for-api-platforms/",
+          "publishedAt": "2026-07-01T00:00:00.000Z",
+          "source": {
+            "name": "Ash Ryan Arnwine",
+            "siteUrl": "https://www.ashryan.io/",
+            "feedUrl": "https://www.ashryan.io/rss/"
+          },
+          "summary": "Collxn Pulse worked because a real person at an audio fingerprinting API helped unlock messier record matching.",
+          "image": "https://www.ashryan.io/images/writing/the-human-touch-still-matters-for-api-platforms/collxn-pulse-feature.jpg"
+        },
         {
           "id": "https://www.ashryan.io/writing/aligning-coding-agents/",
           "title": "Aligning Coding Agents",
@@ -32,19 +45,6 @@
           },
           "summary": "I guess I can't help myself",
           "image": "https://www.ashryan.io/images/writing/my-third-year-leading-ai-coding-sessions-at-itp-camp/img-7654-885f30ec92.jpeg"
-        },
-        {
-          "id": "69fe85a829ed2100017ed4d1",
-          "title": "Kyoto Tech Meetup Coffee links for May 9",
-          "link": "https://www.ashryan.io/writing/kyoto-tech-meetup-coffee-links-for-may-9/",
-          "publishedAt": "2026-05-09T01:43:20.000Z",
-          "source": {
-            "name": "Ash Ryan Arnwine",
-            "siteUrl": "https://www.ashryan.io/",
-            "feedUrl": "https://www.ashryan.io/rss/"
-          },
-          "summary": "Links. Just the links.",
-          "image": "https://images.unsplash.com/photo-1447933601403-0c6688de566e?crop=entropy&amp;cs=tinysrgb&amp;fit=max&amp;fm=jpg&amp;ixid=M3wxMTc3M3wwfDF8c2VhcmNofDN8fGNvZmZlZXxlbnwwfHx8fDE3NzgyNjIyNjR8MA&amp;ixlib=rb-4.1.0&amp;q=80&amp;w=2000"
         }
       ]
     },
@@ -91,6 +91,52 @@
           },
           "summary": "Building a money management app that actually solves real problems",
           "image": null
+        }
+      ]
+    },
+    {
+      "name": "Daniel Kishimoto",
+      "siteUrl": "https://danielkishimoto.com/",
+      "feedUrl": "https://danielkishimoto.com/feed/",
+      "items": [
+        {
+          "id": "https://danielkishimoto.com/?p=1536",
+          "title": "An AI Roasted My Brand.",
+          "link": "https://danielkishimoto.com/blog/2026/06/an-ai-roasted-my-brand/",
+          "publishedAt": "2026-06-26T08:08:21.000Z",
+          "source": {
+            "name": "Daniel Kishimoto",
+            "siteUrl": "https://danielkishimoto.com/",
+            "feedUrl": "https://danielkishimoto.com/feed/"
+          },
+          "summary": "The full story behind GMC’s living rebrand, the part nobody saw, the part that didn’t fit in sixty seconds (of the reel). For Generative Media Club’s first birthday, I let an AI tear my brand apart on camera. They paid me for it. Let me be upfront about what this was. It started as paid […]",
+          "image": "https://danielkishimoto.com/wp-content/uploads/2026/06/ig-claude-partnership.mp4"
+        },
+        {
+          "id": "https://danielkishimoto.com/?p=1480",
+          "title": "My design system met Claude Design",
+          "link": "https://danielkishimoto.com/blog/2026/04/my-design-system-met-claude-design/",
+          "publishedAt": "2026-04-22T14:46:18.000Z",
+          "source": {
+            "name": "Daniel Kishimoto",
+            "siteUrl": "https://danielkishimoto.com/",
+            "feedUrl": "https://danielkishimoto.com/feed/"
+          },
+          "summary": "I’ve been working on GMC’s rebrand for months. Brand identity, design system, a custom SDK to generate marketing assets. Last week Anthropic launched Claude Design — and it rebuilt my entire brandbook in five minutes. I don’t know whether to laugh or feel validated. Probably both. I wasn’t just working on GMC’s visual identity — […]",
+          "image": "https://danielkishimoto.com/wp-content/uploads/2026/04/04222.webm"
+        },
+        {
+          "id": "https://danielkishimoto.com/?p=1454",
+          "title": "[2] AI Fluency is all you need",
+          "link": "https://danielkishimoto.com/blog/2026/02/2-ai-fluency-is-all-you-need/",
+          "publishedAt": "2026-02-24T08:17:46.000Z",
+          "source": {
+            "name": "Daniel Kishimoto",
+            "siteUrl": "https://danielkishimoto.com/",
+            "feedUrl": "https://danielkishimoto.com/feed/"
+          },
+          "summary": "What is “All you need”? A series cutting through AI hype. No tutorials. No hacks that expire in three months. Just key concepts that actually matter—the ones that stick around while everything else changes. Check the index for what’s coming. Every week there’s a new model. A prompting technique you “have to know.” A Twitter […]",
+          "image": "https://danielkishimoto.com/wp-content/uploads/2026/02/chatgpt-o1-thinking.gif"
         }
       ]
     },

--- a/src/data/composite-feed.json
+++ b/src/data/composite-feed.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-10T02:47:58.518Z",
+  "generatedAt": "2026-07-10T03:09:57.119Z",
   "itemsPerFeed": 3,
   "feeds": [
     {
@@ -110,7 +110,7 @@
             "feedUrl": "https://danielkishimoto.com/feed/"
           },
           "summary": "The full story behind GMC’s living rebrand, the part nobody saw, the part that didn’t fit in sixty seconds (of the reel). For Generative Media Club’s first birthday, I let an AI tear my brand apart on camera. They paid me for it. Let me be upfront about what this was. It started as paid […]",
-          "image": "https://danielkishimoto.com/wp-content/uploads/2026/06/ig-claude-partnership.mp4"
+          "image": "https://danielkishimoto.com/wp-content/uploads/2026/06/Frame-5-4.png"
         },
         {
           "id": "https://danielkishimoto.com/?p=1480",
@@ -123,7 +123,7 @@
             "feedUrl": "https://danielkishimoto.com/feed/"
           },
           "summary": "I’ve been working on GMC’s rebrand for months. Brand identity, design system, a custom SDK to generate marketing assets. Last week Anthropic launched Claude Design — and it rebuilt my entire brandbook in five minutes. I don’t know whether to laugh or feel validated. Probably both. I wasn’t just working on GMC’s visual identity — […]",
-          "image": "https://danielkishimoto.com/wp-content/uploads/2026/04/04222.webm"
+          "image": "https://danielkishimoto.com/wp-content/uploads/2026/04/cover-post-1.png"
         },
         {
           "id": "https://danielkishimoto.com/?p=1454",
@@ -136,7 +136,7 @@
             "feedUrl": "https://danielkishimoto.com/feed/"
           },
           "summary": "What is “All you need”? A series cutting through AI hype. No tutorials. No hacks that expire in three months. Just key concepts that actually matter—the ones that stick around while everything else changes. Check the index for what’s coming. Every week there’s a new model. A prompting technique you “have to know.” A Twitter […]",
-          "image": "https://danielkishimoto.com/wp-content/uploads/2026/02/chatgpt-o1-thinking.gif"
+          "image": "https://danielkishimoto.com/wp-content/uploads/2026/02/ai-fluency-2.jpg"
         }
       ]
     },

--- a/src/data/member-feeds.json
+++ b/src/data/member-feeds.json
@@ -12,6 +12,12 @@
     "feedUrl": "https://ashwin.im/rss.xml"
   },
   {
+    "id": "daniel-kishimoto",
+    "name": "Daniel Kishimoto",
+    "siteUrl": "https://danielkishimoto.com/",
+    "feedUrl": "https://danielkishimoto.com/feed/"
+  },
+  {
     "id": "mere-mortal-dev",
     "name": "Mere Mortal Dev",
     "siteUrl": "https://www.youtube.com/@meremortaldev",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -458,7 +458,7 @@ const formatDate = (value: string) => {
                               {item.title}
                             </a>
                             {item.summary ? (
-                              <p class="mt-1 text-sm text-slate-600">
+                              <p class="mt-1 line-clamp-3 text-sm text-slate-600">
                                 {item.summary}
                               </p>
                             ) : null}

--- a/test/fetch-feeds.test.mjs
+++ b/test/fetch-feeds.test.mjs
@@ -1,0 +1,136 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  enrichItemWithLinkedPageImage,
+  extractPageImage,
+  isImageMediaCandidate,
+  resolveFeedImage,
+} from "../scripts/fetch-feeds.mjs";
+
+const blogSource = {
+  name: "Example Author",
+  siteUrl: "https://example.com/",
+  feedUrl: "https://example.com/feed/",
+};
+
+describe("composite feed image selection", () => {
+  test("accepts image enclosures and rejects video enclosures", () => {
+    expect(
+      isImageMediaCandidate({
+        url: "https://example.com/photo.jpg",
+        type: "image/jpeg",
+      }),
+    ).toBe(true);
+    expect(
+      isImageMediaCandidate({
+        url: "https://example.com/demo.mp4",
+        type: "video/mp4",
+      }),
+    ).toBe(false);
+
+    expect(
+      resolveFeedImage(
+        {
+          enclosure: {
+            url: "https://example.com/photo.jpg",
+            type: "image/jpeg",
+          },
+        },
+        blogSource,
+      ),
+    ).toBe("https://example.com/photo.jpg");
+    expect(
+      resolveFeedImage(
+        {
+          enclosure: {
+            url: "https://example.com/demo.webm",
+            type: "video/webm",
+          },
+        },
+        blogSource,
+      ),
+    ).toBeNull();
+  });
+
+  test("keeps semantic media thumbnails and YouTube thumbnails", () => {
+    expect(
+      resolveFeedImage(
+        {
+          "media:thumbnail": {
+            $: { url: "https://cdn.example.com/thumbnail?id=1" },
+          },
+        },
+        blogSource,
+      ),
+    ).toBe("https://cdn.example.com/thumbnail?id=1");
+
+    expect(
+      resolveFeedImage(
+        {
+          videoId: "TGDS3K-1oZ4",
+          enclosure: {
+            url: "https://example.com/video.mp4",
+            type: "video/mp4",
+          },
+        },
+        {
+          name: "Video Author",
+          siteUrl: "https://www.youtube.com/@example",
+          feedUrl: "https://www.youtube.com/@example",
+        },
+      ),
+    ).toBe("https://i.ytimg.com/vi/TGDS3K-1oZ4/hqdefault.jpg");
+  });
+
+  test("prefers page metadata and WordPress featured images", () => {
+    expect(
+      extractPageImage(
+        '<meta property="og:image" content="/social-card.png"><img class="wp-post-image" src="/featured.jpg">',
+        "https://example.com/post/",
+      ),
+    ).toBe("https://example.com/social-card.png");
+
+    expect(
+      extractPageImage(
+        '<img src="/site-logo.svg"><img class="attachment-post-thumbnail wp-post-image" src="/featured.jpg">',
+        "https://example.com/post/",
+      ),
+    ).toBe("https://example.com/featured.jpg");
+  });
+
+  test("uses the linked-page featured image before an inline fallback", async () => {
+    const fetchTextFn = vi.fn(async () =>
+      '<img src="/site-logo.svg"><img class="wp-post-image" src="/featured.jpg">',
+    );
+    const item = await enrichItemWithLinkedPageImage(
+      {
+        id: "post-1",
+        link: "https://example.com/post/",
+        image: null,
+        inlineImage: "https://example.com/inline.gif",
+      },
+      { fetchTextFn },
+    );
+
+    expect(item.image).toBe("https://example.com/featured.jpg");
+    expect(item).not.toHaveProperty("inlineImage");
+  });
+
+  test("retains an inline image when linked-page enrichment fails", async () => {
+    const item = await enrichItemWithLinkedPageImage(
+      {
+        id: "post-1",
+        link: "https://example.com/post/",
+        image: null,
+        inlineImage: "https://example.com/inline.gif",
+      },
+      {
+        fetchTextFn: vi.fn(async () => {
+          throw new Error("offline");
+        }),
+      },
+    );
+
+    expect(item.image).toBe("https://example.com/inline.gif");
+    expect(item).not.toHaveProperty("inlineImage");
+  });
+});


### PR DESCRIPTION
## What changed

- Add Daniel Kishimoto to the member feed source list immediately above Mere Mortal Dev.
- Use `https://danielkishimoto.com/` as the site URL and `https://danielkishimoto.com/feed/` as the RSS source.
- Reject video and audio enclosures instead of passing them to HTML image elements.
- Preserve valid image enclosures, media thumbnails, inline-image fallback, and YouTube thumbnails.
- Prefer linked-page Open Graph and WordPress featured images when a feed has no valid direct image.
- Clamp displayed excerpts to three lines while retaining their full normalized text in the generated JSON.
- Regenerate the composite feed with three recent items from each of the four configured sources.

## Why

Daniel's WordPress feed exposes video files as RSS enclosures. The previous normalizer treated any enclosure URL as an image, which prevented the article-page fallback from finding the actual featured image. The longer WordPress excerpts also rendered without a visual limit.

The revised selection is generic rather than source-specific, so existing blog images and YouTube thumbnails retain their current behavior.

## Validation

- `npm run feeds:pull` completed with 12 items from 4/4 sources
- Confirmed Daniel Kishimoto appears before Mere Mortal Dev in source and generated output order
- Confirmed all three Daniel cards load their WordPress featured images
- Confirmed Ash Ryan, Ashwin, and Mere Mortal Dev image values remain unchanged
- Added regression coverage for image/video enclosures, media thumbnails, YouTube thumbnails, WordPress featured images, and offline inline-image fallback
- `npm run check` (97 tests)
- `npx astro build`
- English desktop and Japanese mobile visual review
- Confirmed three-line summary clamping and no page-level horizontal overflow
