### PR TITLE
Add agent discovery Link headers

### DIFF
--- a/scripts/security-headers.mjs
+++ b/scripts/security-headers.mjs
@@ -72,6 +72,7 @@ export async function writeCloudflareHeaders(outputDirectory) {
     "  X-Frame-Options: DENY",
     "  Referrer-Policy: strict-origin-when-cross-origin",
     "  Permissions-Policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()",
+    '  Link: </sitemap-index.xml>; rel="sitemap", </.well-known/security.txt>; rel="describedby"; type="text/plain"',
   ];
 
   for (const htmlFile of htmlFiles) {

--- a/test/security-headers.test.mjs
+++ b/test/security-headers.test.mjs
@@ -40,6 +40,9 @@ describe("Cloudflare security headers", () => {
     expect(headers).toContain("Strict-Transport-Security");
     expect(headers).toContain("X-Frame-Options: DENY");
     expect(headers).toContain("Permissions-Policy:");
+    expect(headers).toContain(
+      'Link: </sitemap-index.xml>; rel="sitemap", </.well-known/security.txt>; rel="describedby"; type="text/plain"',
+    );
     expect(headers).toContain("\n/\n  Content-Security-Policy:");
     expect(headers).toContain("\n/ja/\n  Content-Security-Policy:");
   });


### PR DESCRIPTION
## Summary

- adds RFC 8288 `Link` response headers to Cloudflare Pages output
- advertises the existing sitemap and vulnerability-reporting resource
- keeps the header generation centralized with the existing security header baseline

## Verification

- `npm run check`
- `npx astro build`
- focused security-header tests confirm the generated `_headers` file contains the Link field

## Scope note

The agent-readiness scanner also reports API, OAuth, MCP, WebMCP, DNS-AID, and Markdown-for-Agents checks. This site does not expose APIs, authentication, MCP tools, or agent skills, so this PR does not publish misleading discovery documents. Markdown-for-Agents is a Cloudflare zone setting and can be enabled separately under AI Crawl Control if desired.
