### PR TITLE
Add Markdown negotiation for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ dist/
 # generated types
 .astro/
 
+# build-generated agent Markdown
+public/agent-home.en.md
+public/agent-home.ja.md
+
 # dependencies
 node_modules/
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Everything here is maintained by community members; contributions that make the 
 | `npm run check`    | Runs lint, type-check, Astro check, and Knip in sequence.               |
 | `npm run events:pull` | Refreshes the committed Meetup event cache and fails on errors.      |
 | `npm run events:pull:stale-ok` | Refreshes Meetup events or preserves the last valid cache. |
+| `npm run agent:markdown` | Generates the English and Japanese Markdown responses used for agent content negotiation. |
 | `npm run feeds:notify` | Polls approved member feeds and posts unseen items to configured channels. |
 | `npm run feeds:notify:dry-run` | Shows what the notifier would send without posting or updating state. |
 | `npm run preview`  | Serves the production build locally.                                    |
@@ -98,6 +99,13 @@ public/          # Files served as-is (favicon, images)
 - `npm run events:pull:stale-ok` keeps the last valid snapshot when Meetup is temporarily unavailable. Production builds use this mode.
 - Page rendering reads only the committed snapshot; it does not make live Meetup requests while generating `/` and `/ja/`.
 - Event reminders continue to fetch live Meetup data because they run as a separate operational workflow.
+
+## Markdown for agents
+
+- `npm run agent:markdown` generates ignored build files at `public/agent-home.en.md` and `public/agent-home.ja.md` from the committed event and member-feed snapshots.
+- Production builds run this generator after the stale-safe event/feed refreshes.
+- Cloudflare Pages Functions at `/` and `/ja/` return those files only when the request explicitly accepts `text/markdown`; normal browser requests continue to receive the Astro HTML pages.
+- Verify locally or against a preview with `curl -H 'Accept: text/markdown' -D - https://preview-url/`.
 
 ## Community Feed Notifier
 

--- a/functions/_lib/markdown.js
+++ b/functions/_lib/markdown.js
@@ -1,0 +1,29 @@
+/* global URL, Request, Headers, Response */
+
+export function acceptsMarkdown(header) {
+  return String(header ?? "").split(",").some((part) => {
+    const [mediaType, ...parameters] = part.trim().toLowerCase().split(";");
+    if (mediaType !== "text/markdown" && mediaType !== "text/*") return false;
+    const quality = parameters.find((parameter) => parameter.trim().startsWith("q="));
+    return !quality || Number(quality.trim().slice(2)) > 0;
+  });
+}
+
+export async function serveMarkdown(context, assetPath) {
+  const assetUrl = new URL(assetPath, context.request.url);
+  const assetResponse = await context.env.ASSETS.fetch(new Request(assetUrl, context.request));
+  if (!assetResponse.ok) return assetResponse;
+  const headers = new Headers(assetResponse.headers);
+  headers.set("Content-Type", "text/markdown; charset=utf-8");
+  headers.set("Vary", "Accept");
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  return new Response(assetResponse.body, { status: 200, headers });
+}
+
+export function handleMarkdownRequest(context, assetPath) {
+  return acceptsMarkdown(context.request.headers.get("Accept"))
+    ? serveMarkdown(context, assetPath)
+    : context.env.ASSETS.fetch(context.request);
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,5 @@
+import { handleMarkdownRequest } from "./_lib/markdown.js";
+
+export function onRequestGet(context) {
+  return handleMarkdownRequest(context, "/agent-home.en.md");
+}

--- a/functions/ja/index.js
+++ b/functions/ja/index.js
@@ -1,0 +1,5 @@
+import { handleMarkdownRequest } from "../_lib/markdown.js";
+
+export function onRequestGet(context) {
+  return handleMarkdownRequest(context, "/agent-home.ja.md");
+}

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,3 @@
+{
+  "entry": ["functions/**/*.js"]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "astro": "astro",
     "astrocheck": "astro check",
-    "build": "npm run feeds:pull:stale-ok && npm run events:pull:stale-ok && astro build",
+    "agent:markdown": "node scripts/agent-markdown.mjs",
+    "build": "npm run feeds:pull:stale-ok && npm run events:pull:stale-ok && npm run agent:markdown && astro build",
     "check": "npm run lint; npm run tsc; npm run knip; npm run test; npm run astrocheck; npm run images:check",
     "dev": "astro dev",
     "feeds:notify": "node scripts/community-feed-notifier.mjs",

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/", "/ja/"],
+  "exclude": []
+}

--- a/scripts/agent-markdown.mjs
+++ b/scripts/agent-markdown.mjs
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PUBLIC_DIR = path.join(ROOT, "public");
+
+const links = {
+  meetup: "https://www.meetup.com/kyoto-tech-meetup/",
+  discord: "https://discord.gg/mXFWEHDKeu",
+  github: "https://github.com/kyoto-tech",
+  linkedin: "https://www.linkedin.com/company/kyoto-tech-meetup/",
+  contact: "https://forms.gle/NPtc1G1vM9jGBYhp6",
+};
+
+function escapeMarkdown(value) {
+  return String(value ?? "").replace(/[\\`*_[\]]/g, "\\$&").trim();
+}
+
+function safeHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function eventMapUrl(venue) {
+  const parts = [venue?.name, venue?.address, venue?.city, venue?.state, venue?.country]
+    .map((part) => (typeof part === "string" ? part.trim() : ""))
+    .filter(Boolean);
+  if (parts.length === 0) return null;
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(parts.join(", "))}`;
+}
+
+function formatDate(value, locale) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "Date to be confirmed";
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "full",
+    timeStyle: "short",
+    timeZone: "Asia/Tokyo",
+  }).format(date);
+}
+
+function formatEvent(event, locale) {
+  const eventUrl = safeHttpUrl(event.link) ?? links.meetup;
+  const mapUrl = eventMapUrl(event.venue);
+  const venue = event.venue?.name || event.venue?.city || "Kyoto";
+  const attendance = Number.isFinite(event.goingCount) ? ` · ${event.goingCount} going` : "";
+  const map = mapUrl ? ` · [Open in Maps](${mapUrl})` : "";
+  return `- **[${escapeMarkdown(event.title)}](${eventUrl})** — ${formatDate(event.start, locale)} — ${escapeMarkdown(venue)}${attendance}${map}`;
+}
+
+function validEvents(snapshot) {
+  const events = Array.isArray(snapshot?.events) ? snapshot.events : [];
+  return events
+    .filter((event) => event && typeof event === "object")
+    .filter((event) => safeHttpUrl(event.link) && !Number.isNaN(new Date(event.start).valueOf()))
+    .sort((a, b) => new Date(a.start).valueOf() - new Date(b.start).valueOf());
+}
+
+function validFeedItems(snapshot) {
+  const feeds = Array.isArray(snapshot?.feeds) ? snapshot.feeds : [];
+  return feeds
+    .flatMap((feed) => (Array.isArray(feed.items) ? feed.items : []).map((item) => ({ ...item, sourceName: feed.name })))
+    .filter((item) => item && safeHttpUrl(item.link))
+    .sort((a, b) => new Date(b.publishedAt).valueOf() - new Date(a.publishedAt).valueOf());
+}
+
+export function buildAgentMarkdown({ eventsSnapshot, feedSnapshot, locale = "en-US", now = new Date() }) {
+  const events = validEvents(eventsSnapshot).filter((event) => new Date(event.start).valueOf() >= now.valueOf());
+  const items = validFeedItems(feedSnapshot).slice(0, 8);
+  const japanese = locale === "ja-JP";
+  const eventHeading = japanese ? "## 次回・今後のミートアップ" : "## Next and upcoming meetups";
+  const feedHeading = japanese ? "## メンバーが発信していること" : "## What members are publishing";
+  const eventEmpty = japanese
+    ? "現在予定されているイベントはありません。最新情報はMeetupページをご確認ください。"
+    : "There are no upcoming events in the current snapshot. Check Meetup for the latest information.";
+  const eventLines = events.length > 0 ? events.slice(0, 8).map((event) => formatEvent(event, locale)).join("\n") : eventEmpty;
+  const feedLines = items.length > 0
+    ? items.map((item) => `- **[${escapeMarkdown(item.title)}](${item.link})** — ${escapeMarkdown(item.sourceName)}${item.publishedAt ? ` · ${formatDate(item.publishedAt, locale)}` : ""}`).join("\n")
+    : japanese ? "現在、掲載されているメンバー記事はありません。" : "There are no published member items in the current snapshot.";
+  const generatedAt = eventsSnapshot?.generatedAt || feedSnapshot?.generatedAt || "unknown";
+  const intro = japanese
+    ? "Kyoto Tech Meetupは、京都で英語・日本語を使いながら、会話とハンズオンのものづくりを楽しむコミュニティです。初心者、地元の方、旅行者を歓迎しています。"
+    : "Kyoto Tech Meetup is a community in Kyoto for conversation and hands-on building in English and Japanese. Newcomers, locals, nomads, and travelers are welcome.";
+  const linksHeading = japanese ? "## コミュニティリンク" : "## Community links";
+  const linksLines = japanese
+    ? `- [Meetupで参加する](${links.meetup})\n- [Discordに参加する](${links.discord})\n- [GitHubを見る](${links.github})\n- [LinkedInでつながる](${links.linkedin})\n- [問い合わせる](${links.contact})`
+    : `- [Join on Meetup](${links.meetup})\n- [Join Discord](${links.discord})\n- [View GitHub](${links.github})\n- [Network on LinkedIn](${links.linkedin})\n- [Contact the organizers](${links.contact})`;
+  return `# Kyoto Tech Meetup\n\n${intro}\n\n${eventHeading}\n\n${eventLines}\n\n${feedHeading}\n\n${feedLines}\n\n${linksHeading}\n\n${linksLines}\n\n---\n\n${japanese ? "この情報のイベントスナップショット" : "Event snapshot"}: ${generatedAt}\n`;
+}
+
+export async function writeAgentMarkdown({ eventsPath = path.join(ROOT, "src/data/meetup-events.json"), feedsPath = path.join(ROOT, "src/data/composite-feed.json"), outputDirectory = PUBLIC_DIR } = {}) {
+  const [eventsSnapshot, feedSnapshot] = await Promise.all([
+    fs.readFile(eventsPath, "utf8").then(JSON.parse),
+    fs.readFile(feedsPath, "utf8").then(JSON.parse),
+  ]);
+  await fs.mkdir(outputDirectory, { recursive: true });
+  await Promise.all([
+    fs.writeFile(path.join(outputDirectory, "agent-home.en.md"), buildAgentMarkdown({ eventsSnapshot, feedSnapshot, locale: "en-US" })),
+    fs.writeFile(path.join(outputDirectory, "agent-home.ja.md"), buildAgentMarkdown({ eventsSnapshot, feedSnapshot, locale: "ja-JP" })),
+  ]);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) await writeAgentMarkdown();

--- a/test/agent-markdown.test.mjs
+++ b/test/agent-markdown.test.mjs
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { acceptsMarkdown } from "../functions/_lib/markdown.js";
+import { buildAgentMarkdown } from "../scripts/agent-markdown.mjs";
+
+describe("agent Markdown negotiation", () => {
+  test("recognizes an explicit Markdown preference", () => {
+    expect(acceptsMarkdown("text/markdown")).toBe(true);
+    expect(acceptsMarkdown("text/html, text/markdown;q=0.9")).toBe(true);
+    expect(acceptsMarkdown("text/markdown;q=0")).toBe(false);
+    expect(acceptsMarkdown("text/html, */*;q=0.8")).toBe(false);
+  });
+});
+
+describe("agent Markdown content", () => {
+  test("includes current events and curated member posts", () => {
+    const markdown = buildAgentMarkdown({
+      now: new Date("2026-07-10T00:00:00Z"),
+      eventsSnapshot: {
+        generatedAt: "2026-07-10T00:00:00Z",
+        events: [
+          {
+            title: "Next meetup",
+            link: "https://www.meetup.com/kyoto-tech-meetup/events/123/",
+            start: "2026-07-20T09:00:00+09:00",
+            goingCount: 4,
+            venue: { name: "Kyoto Cafe", city: "Kyoto", country: "JP" },
+          },
+          {
+            title: "Past meetup",
+            link: "https://www.meetup.com/kyoto-tech-meetup/events/old/",
+            start: "2026-07-01T09:00:00+09:00",
+            goingCount: 1,
+          },
+        ],
+      },
+      feedSnapshot: {
+        generatedAt: "2026-07-10T00:00:00Z",
+        feeds: [
+          {
+            name: "Member One",
+            items: [
+              {
+                title: "A published post",
+                link: "https://example.com/post",
+                publishedAt: "2026-07-09T00:00:00Z",
+              },
+              {
+                title: "Unsafe item",
+                link: "javascript:alert(1)",
+                publishedAt: "2026-07-10T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(markdown).toContain("## Next and upcoming meetups");
+    expect(markdown).toContain("Next meetup");
+    expect(markdown).not.toContain("Past meetup");
+    expect(markdown).toContain("## What members are publishing");
+    expect(markdown).toContain("A published post");
+    expect(markdown).not.toContain("Unsafe item");
+    expect(markdown).toContain("Join Discord");
+  });
+});


### PR DESCRIPTION
## Summary

- adds a build-generated English/Japanese Markdown representation of the homepage
- adds route-scoped Cloudflare Pages Functions for `/` and `/ja/` that negotiate `Accept: text/markdown`
- keeps browser HTML and static assets on the existing static path
- adds `_routes.json`, generated-content ignore rules, and Knip entry configuration
- validates event/member-feed links and includes current event, RSVP, map, community, and published member-content links

## Verification

- `npm run check`
- `npm run build`
- `npx astro build`
- focused negotiation/content tests
- local function simulation confirms `200`, `text/markdown`, and `Vary: Accept`

## Preview acceptance

The deployed preview should confirm:

```bash
curl -H 'Accept: text/markdown' -D - https://preview-url/
curl -D - https://preview-url/
curl -H 'Accept: text/markdown' -D - https://preview-url/ja/
```

The first and third requests should return Markdown; the browser request should remain HTML.
