### PR TITLE
Close out event and community feed workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,14 @@ public/          # Files served as-is (favicon, images)
 - Cloudflare Pages Functions at `/` and `/ja/` return those files only when the request explicitly accepts `text/markdown`; normal browser requests continue to receive the Astro HTML pages.
 - Verify locally or against a preview with `curl -H 'Accept: text/markdown' -D - https://preview-url/`.
 - The Markdown maintenance skill is published at `/.well-known/agent-skills/markdown-for-agents/SKILL.md`; `npm run agent:skills` regenerates its discovery index digest during builds.
+- The WebMCP maintenance skill is published at `/.well-known/agent-skills/webmcp-maintenance/SKILL.md`; `npm run build` verifies the Markdown, Agent Skills, and WebMCP artifacts before completing.
 
 ## Community Feed Notifier
 
 - The notifier reads approved sources from `src/data/member-feeds.json`.
 - Each feed source has a stable `id`; do not change it casually because notifier state keys are derived from it.
+- New feed sources are recorded in the gist-backed `sources` map and their existing backlog is suppressed; future items are notified without historical backfill.
+- Feed excerpts use the same 280-character normalization for the site and notifications, and notifier items can enrich missing images from linked-page metadata.
 - State lives in the public gist `f95dd7597eec170d738d905e3666bfc6` as `community-feed-state.json`.
 - On the first non-dry run, the notifier seeds the current backlog into the gist without posting. Use the workflow dispatch input `allow_initial_posts` if you intentionally want to announce the backlog.
 - For a lightweight demo, use the workflow dispatch input `demo_mode`. It posts at most 3 items and seeds the rest of the current backlog so later scheduled runs do not replay the full backlog.

--- a/docs/agent-readiness-roadmap.md
+++ b/docs/agent-readiness-roadmap.md
@@ -1,6 +1,6 @@
 # Agent Readiness Roadmap
 
-Status: Proposed — Link headers are implemented separately in PR 107
+Status: Core work complete — PRs 107–112 merged; DNSSEC and authoring workflows deferred
 
 ## Purpose
 
@@ -20,7 +20,7 @@ DNS-AID remains deferred until the site has a real agent endpoint or capability 
 - Link headers advertising the sitemap and security contact are implemented in PR 107.
 - The site is a static Astro build deployed to Cloudflare Pages.
 - Meetup events and member feeds are fetched at build time and rendered from committed JSON snapshots.
-- There is no public API, OAuth provider, MCP server, authenticated service, or agent skill registry.
+- There is no public API, OAuth provider, MCP server, or authenticated service. The Agent Skills index and WebMCP read-only tools are live.
 - Cloudflare’s managed Markdown for Agents feature may not be available on the zone’s current Free plan.
 
 ## Delivery order
@@ -32,7 +32,7 @@ DNS-AID remains deferred until the site has a real agent endpoint or capability 
 | C | DNSSEC activation | Registrar access at Hover | Cloudflare DNS answers are cryptographically authenticated |
 | D | DNS-AID evaluation | A real agent endpoint or capability descriptor | Decide whether an SVCB/HTTPS record would describe a genuine service |
 
-PRs A and C can proceed independently. PR B should not begin until the event/feed JSON contract is confirmed and its read-only footprint is reviewed.
+PRs A and B are complete. DNSSEC remains an independent infrastructure project, and WebMCP author/content actions remain deferred until explicit organizer approval and a separate permission review.
 
 ---
 

--- a/docs/homepage-redesign-roadmap.md
+++ b/docs/homepage-redesign-roadmap.md
@@ -1,6 +1,6 @@
 # Homepage Redesign Roadmap
 
-Status: Active — PRs 1–7 and 4A merged; PR 8 final QA in review
+Status: Core redesign complete — PRs 1–8 merged; closeout polish and feed operations remain
 Primary audience: People considering their first Kyoto Tech Meetup  
 Secondary audience: Existing community members looking for events, venue details, conversations, and member work
 
@@ -67,6 +67,20 @@ Final invitation and footer
 | 8 | Accessibility, performance, analytics, and final QA | PRs 3–7 | The complete journey is verified and measurable |
 
 PR 1 and PR 2 can be developed in parallel. Later PRs should follow the dependency order above.
+
+## Closeout work
+
+The core redesign is complete, including the member milestone and the shared “happening now” state across the hero, mobile event list, and desktop calendar. The remaining work is intentionally split into small operational and polish PRs:
+
+| PR | Workstream | Depends on | Primary outcome |
+| --- | --- | --- | --- |
+| 9 | Event detail UI polish | 4A and 6 | Align Maps metadata and remove excess calendar spacing |
+| 10 | Shared feed content contract | Existing feed and notifier readers | Keep excerpts, URLs, attribution, and image selection consistent |
+| 11 | YouTube reliability and stale fallback | 10 | Retry transient YouTube failures and preserve each source’s last good snapshot |
+| 12 | Discord source onboarding | Existing gist-backed notifier state | Prevent historical backfill when a feed is newly added |
+| 13 | Final QA and documentation | 9–12 | Verify the full site/feed/notification workflow and close the roadmap |
+
+Keep DNSSEC and any future WebMCP authoring workflows outside this closeout sequence; they remain separate, optional initiatives.
 
 ---
 

--- a/scripts/community-feed-notifier.mjs
+++ b/scripts/community-feed-notifier.mjs
@@ -1,4 +1,5 @@
 import {
+  enrichNotifierItemWithLinkedPageImage,
   fetchFeedItems,
   fetchWithTimeout,
   loadMemberFeeds,
@@ -7,6 +8,7 @@ import {
   buildDiscordPayload,
   buildMessage,
   defaultState,
+  initializeNewFeedSources,
   migrateStateItemIds,
   readStateFromGist,
   upsertStateRecord,
@@ -228,7 +230,10 @@ async function main() {
         maxItemsPerFeed: args.maxItemsPerFeed,
         userAgent: USER_AGENT,
       });
-      allItems.push(...items);
+      const enrichedItems = await Promise.all(
+        items.map((item) => enrichNotifierItemWithLinkedPageImage(item)),
+      );
+      allItems.push(...enrichedItems);
     } catch (error) {
       fetchFailures.push({
         source: source.name,
@@ -257,6 +262,7 @@ async function main() {
     (a, b) => new Date(a.publishedAt).valueOf() - new Date(b.publishedAt).valueOf(),
   );
   const isFirstRun = Object.keys(state.items).length === 0;
+  const newlyInitializedSources = initializeNewFeedSources(state, memberFeeds, now);
 
   if (isFirstRun && !args.allowInitialPosts) {
     for (const item of sortedItems) {
@@ -284,7 +290,7 @@ async function main() {
   const deliveryFailures = [];
   let limitedItems = 0;
   let processedItems = 0;
-  let stateChanged = migration.changed;
+  let stateChanged = migration.changed || newlyInitializedSources.size > 0;
 
   if (stateChanged) {
     state.initializedAt = state.initializedAt || now;
@@ -302,6 +308,12 @@ async function main() {
 
   for (const item of sortedItems) {
     const record = upsertStateRecord(state, item, now);
+
+    if (!args.allowInitialPosts && newlyInitializedSources.has(item.source.id)) {
+      record.suppressed = true;
+      stateChanged = true;
+      continue;
+    }
 
     if (record.suppressed) continue;
     if (!hasPendingDestinations(record, destinations)) continue;
@@ -340,6 +352,10 @@ async function main() {
     fetchFailures.forEach((failure) => {
       console.warn(`[notifier] Feed fetch failed for ${failure.source}: ${failure.error}`);
     });
+  }
+
+  if (stateChanged && !args.dryRun && newDeliveries === 0) {
+    await writeStateToGist(gistId, gistToken, state, GIST_OPTIONS);
   }
 
   if (!stateChanged) {

--- a/scripts/fetch-feeds.mjs
+++ b/scripts/fetch-feeds.mjs
@@ -6,6 +6,7 @@ import Parser from "rss-parser";
 import {
   fetchRawFeedItems,
   fetchText,
+  extractImageUrl,
   isHttpUrl,
   isYoutubeUrl,
   loadMemberFeeds,
@@ -375,6 +376,9 @@ export function resolveFeedImage(rawItem, source) {
     }
   }
 
+  const sharedImage = extractImageUrl(rawItem, source);
+  if (sharedImage) return sharedImage;
+
   return null;
 }
 
@@ -429,7 +433,7 @@ function normalizeItem(rawItem, source) {
       siteUrl: source.siteUrl,
       feedUrl: source.feedUrl,
     },
-    summary: truncate(summary, 360),
+    summary: truncate(summary),
     image: resolveFeedImage(rawItem, source),
     inlineImage: resolveInlineContentImage(rawItem, source),
   };
@@ -480,9 +484,18 @@ async function readExisting(filePath) {
   }
 }
 
+export function getCachedFeedForSource(existing, source) {
+  return existing?.feeds?.find((feed) =>
+    feed.feedUrl === source.feedUrl ||
+    feed.siteUrl === source.siteUrl ||
+    feed.name === source.name,
+  ) ?? null;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const memberFeeds = await loadMemberFeeds();
+  const existing = args.staleOk ? await readExisting(args.outputPath) : null;
   const parser = new Parser();
   const now = new Date();
   const failures = [];
@@ -505,19 +518,24 @@ async function main() {
       );
 
       feedsWithItems.push({
+        id: source.id,
         name: source.name,
         siteUrl: source.siteUrl,
         feedUrl: source.feedUrl,
         items: itemsWithLinkedPageImages,
       });
     } catch (error) {
-      failures.push({ source: source.name, error: error?.message || String(error) });
+      const message = error?.message || String(error);
+      failures.push({ source: source.name, error: message });
+      const cached = getCachedFeedForSource(existing, source);
       feedsWithItems.push({
+        id: source.id,
         name: source.name,
         siteUrl: source.siteUrl,
         feedUrl: source.feedUrl,
-        items: [],
-        error: error?.message || String(error),
+        items: args.staleOk && Array.isArray(cached?.items) ? cached.items : [],
+        error: message,
+        usedFallback: Boolean(args.staleOk && cached?.items?.length),
       });
     }
   }
@@ -535,7 +553,6 @@ async function main() {
   };
 
   if (totalItems === 0 && args.staleOk) {
-    const existing = await readExisting(args.outputPath);
     if (existing?.feeds?.length) {
       console.warn(
         `[feeds] Using existing data from ${args.outputPath} because fetching produced no items.`,

--- a/scripts/lib/community-feed-notifier-state.mjs
+++ b/scripts/lib/community-feed-notifier-state.mjs
@@ -90,6 +90,7 @@ export function defaultState() {
     initializedAt: null,
     updatedAt: null,
     items: {},
+    sources: {},
     events: {},
     weeklyDigest: {},
   };
@@ -110,6 +111,10 @@ export function parseState(content) {
     items:
       parsed.items && typeof parsed.items === "object" && !Array.isArray(parsed.items)
         ? parsed.items
+        : {},
+    sources:
+      parsed.sources && typeof parsed.sources === "object" && !Array.isArray(parsed.sources)
+        ? parsed.sources
         : {},
     events:
       parsed.events && typeof parsed.events === "object" && !Array.isArray(parsed.events)
@@ -206,6 +211,9 @@ export function migrateStateItemIds(state, sources) {
   if (!state.events || typeof state.events !== "object" || Array.isArray(state.events)) {
     state.events = {};
   }
+  if (!state.sources || typeof state.sources !== "object" || Array.isArray(state.sources)) {
+    state.sources = {};
+  }
   if (!state.weeklyDigest || typeof state.weeklyDigest !== "object" || Array.isArray(state.weeklyDigest)) {
     state.weeklyDigest = {};
   }
@@ -218,6 +226,34 @@ export function migrateStateItemIds(state, sources) {
     changed: migratedCount > 0 || previousVersion !== CURRENT_STATE_VERSION,
     migratedCount,
   };
+}
+
+export function initializeNewFeedSources(state, sources, initializedAt) {
+  const newlyInitialized = new Set();
+  state.sources = state.sources && typeof state.sources === "object" ? state.sources : {};
+  const knownSourceIds = new Set(
+    Object.values(state.items || {})
+      .map((item) => item?.source?.id)
+      .filter(Boolean),
+  );
+
+  for (const source of sources) {
+    if (state.sources[source.id]) continue;
+    if (knownSourceIds.has(source.id)) {
+      state.sources[source.id] = {
+        initializedAt: state.initializedAt || initializedAt,
+        feedUrl: source.feedUrl,
+      };
+      continue;
+    }
+    state.sources[source.id] = {
+      initializedAt,
+      feedUrl: source.feedUrl,
+    };
+    newlyInitialized.add(source.id);
+  }
+
+  return newlyInitialized;
 }
 
 export function upsertStateRecord(state, item, seenAt, options = {}) {

--- a/scripts/lib/community-feed-reader.mjs
+++ b/scripts/lib/community-feed-reader.mjs
@@ -196,7 +196,36 @@ function htmlImageUrl(value, baseUrl) {
   }
 }
 
-function extractImageUrl(rawItem, source) {
+function resolveHtmlImageUrl(value, baseUrl) {
+  if (!value || typeof value !== "string") return "";
+  const metaCandidates = Array.from(
+    value.matchAll(/<meta\b[^>]*(?:property|name)=["'](?:og:image|og:image:url|twitter:image)["'][^>]*>/gi),
+  ).map((match) => match[0].match(/content=["']([^"']+)["']/i)?.[1]);
+  const imageTags = Array.from(value.matchAll(/<img\b[^>]*>/gi)).map(
+    (match) => match[0],
+  );
+  const featuredCandidates = imageTags
+    .filter((tag) => /class=["'][^"']*wp-post-image[^"']*["']/i.test(tag))
+    .map((tag) => tag.match(/(?:src|data-src)=["']([^"']+)["']/i)?.[1]);
+  const fallbackCandidates = imageTags
+    .map((tag) => tag.match(/(?:src|data-src)=["']([^"']+)["']/i)?.[1])
+    .filter(Boolean);
+  const candidates = [...metaCandidates, ...featuredCandidates, ...fallbackCandidates];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const absoluteUrl = new URL(candidate, baseUrl).toString();
+      if (isHttpUrl(absoluteUrl)) return absoluteUrl;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return "";
+}
+
+export function extractImageUrl(rawItem, source) {
   const baseUrl = rawItem.link || source.siteUrl;
   const candidates = [
     enclosureImageUrl(rawItem.enclosure),
@@ -213,6 +242,7 @@ function extractImageUrl(rawItem, source) {
   ];
 
   for (const candidate of candidates) {
+    if (!candidate) continue;
     try {
       const absoluteUrl = new URL(candidate, baseUrl).toString();
       if (isHttpUrl(absoluteUrl)) return absoluteUrl;
@@ -286,6 +316,23 @@ export function normalizeNotifierItem(rawItem, source) {
   };
 }
 
+export async function enrichNotifierItemWithLinkedPageImage(
+  item,
+  { fetchTextFn = fetchText } = {},
+) {
+  if (item.imageUrl || !isHttpUrl(item.link)) return item;
+
+  try {
+    const html = await fetchTextFn(item.link);
+    return {
+      ...item,
+      imageUrl: resolveHtmlImageUrl(html, item.link) || null,
+    };
+  } catch {
+    return item;
+  }
+}
+
 export function normalizeAndLimitFeedItems(
   rawItems,
   source,
@@ -325,7 +372,13 @@ export async function fetchRawFeedItems(
     feedTimeoutMs,
     userAgent,
   });
-  const xml = await fetchTextFn(resolvedFeedUrl, {}, feedTimeoutMs, userAgent);
+  let xml;
+  try {
+    xml = await fetchTextFn(resolvedFeedUrl, {}, feedTimeoutMs, userAgent);
+  } catch (error) {
+    if (!isYoutubeUrl(resolvedFeedUrl)) throw error;
+    xml = await fetchTextFn(resolvedFeedUrl, {}, feedTimeoutMs, userAgent);
+  }
   const parsed = await parser.parseString(xml);
   return parsed?.items || [];
 }

--- a/src/components/Calendar.astro
+++ b/src/components/Calendar.astro
@@ -126,7 +126,7 @@ const eventColorClass = (event: MeetupEvent) => {
                             >
                               {event.title}
                             </a>
-                            <div class="mt-2 grid gap-1 text-[0.6875rem] font-medium text-white/90">
+                            <div class="mt-1 grid gap-0.5 text-[0.6875rem] font-medium leading-tight text-white/90">
                               <span
                                 class="inline-flex items-center gap-1.5"
                               >
@@ -152,7 +152,7 @@ const eventColorClass = (event: MeetupEvent) => {
                                   data-analytics-event="calendar_event_click"
                                   data-analytics-link="maps"
                                   data-analytics-location="desktop_calendar"
-                                  class="inline-flex min-h-11 items-center gap-1.5 underline decoration-white/50 underline-offset-2 transition hover:text-white hover:decoration-white focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                                  class="inline-flex items-center gap-1.5 py-1 underline decoration-white/50 underline-offset-2 transition hover:text-white hover:decoration-white focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                                 >
                                   <FaLocationDot
                                     className="h-3 w-3 shrink-0"

--- a/src/components/NextEventCard.astro
+++ b/src/components/NextEventCard.astro
@@ -56,7 +56,7 @@ const venueLabel = event?.venue?.name ?? event?.venue?.address ?? "";
           {state.title}
         </h2>
         <dl class="mt-4 grid gap-2.5 text-sm text-slate-600">
-          <div class="flex items-start gap-2.5">
+          <div class="flex items-center gap-2.5">
             <svg aria-hidden="true" viewBox="0 0 24 24" class="mt-0.5 h-4 w-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.8">
               <path stroke-linecap="round" stroke-linejoin="round" d="M7 3v3m10-3v3M4.5 9.5h15M5 5h14a1 1 0 0 1 1 1v14H4V6a1 1 0 0 1 1-1Z" />
             </svg>
@@ -67,7 +67,7 @@ const venueLabel = event?.venue?.name ?? event?.venue?.address ?? "";
               </time>
             </dd>
           </div>
-          <div class="flex items-start gap-2.5">
+          <div class="flex items-center gap-2.5">
             <svg aria-hidden="true" viewBox="0 0 24 24" class="mt-0.5 h-4 w-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.8">
               <path stroke-linecap="round" stroke-linejoin="round" d="M20 10c0 5-8 11-8 11S4 15 4 10a8 8 0 1 1 16 0Z" />
               <circle cx="12" cy="10" r="2.5" />
@@ -76,7 +76,7 @@ const venueLabel = event?.venue?.name ?? event?.venue?.address ?? "";
             <dd>{state.venueName ?? t("home.eventCard.venueTba")}</dd>
           </div>
           <div
-            class="flex items-start gap-2.5"
+            class="flex items-center gap-2.5"
           >
             <FaUserGroup
               className="mt-0.5 h-4 w-4 shrink-0"
@@ -92,7 +92,7 @@ const venueLabel = event?.venue?.name ?? event?.venue?.address ?? "";
           </div>
           {
             mapsUrl ? (
-              <div class="flex items-start gap-2.5">
+              <div class="flex items-center gap-2.5">
                 <FaLocationDot
                   className="mt-0.5 h-4 w-4 shrink-0"
                   aria-hidden="true"
@@ -106,7 +106,7 @@ const venueLabel = event?.venue?.name ?? event?.venue?.address ?? "";
                     data-analytics-event="calendar_event_click"
                     data-analytics-link="maps"
                     data-analytics-location="hero_event_card"
-                    class="inline-flex min-h-11 items-center font-medium text-slate-700 underline decoration-slate-300 underline-offset-2 transition hover:text-slate-950 hover:decoration-(--accent) focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700"
+                    class="inline-flex min-h-0 items-center py-1 font-medium leading-tight text-slate-700 underline decoration-slate-300 underline-offset-2 transition hover:text-slate-950 hover:decoration-(--accent) focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700"
                   >
                     {t("home.calendar.openInMaps")}
                     <span class="sr-only">: {venueLabel}</span>

--- a/src/data/composite-feed.json
+++ b/src/data/composite-feed.json
@@ -1,8 +1,9 @@
 {
-  "generatedAt": "2026-07-10T03:09:57.119Z",
+  "generatedAt": "2026-07-10T08:13:47.643Z",
   "itemsPerFeed": 3,
   "feeds": [
     {
+      "id": "ash-ryan-arnwine",
       "name": "Ash Ryan Arnwine",
       "siteUrl": "https://www.ashryan.io/",
       "feedUrl": "https://www.ashryan.io/rss/",
@@ -49,6 +50,7 @@
       ]
     },
     {
+      "id": "ashwin-anil",
       "name": "Ashwin Anil",
       "siteUrl": "https://ashwin.im/",
       "feedUrl": "https://ashwin.im/rss.xml",
@@ -95,6 +97,7 @@
       ]
     },
     {
+      "id": "daniel-kishimoto",
       "name": "Daniel Kishimoto",
       "siteUrl": "https://danielkishimoto.com/",
       "feedUrl": "https://danielkishimoto.com/feed/",
@@ -109,7 +112,7 @@
             "siteUrl": "https://danielkishimoto.com/",
             "feedUrl": "https://danielkishimoto.com/feed/"
           },
-          "summary": "The full story behind GMC’s living rebrand, the part nobody saw, the part that didn’t fit in sixty seconds (of the reel). For Generative Media Club’s first birthday, I let an AI tear my brand apart on camera. They paid me for it. Let me be upfront about what this was. It started as paid […]",
+          "summary": "The full story behind GMC’s living rebrand, the part nobody saw, the part that didn’t fit in sixty seconds (of the reel). For Generative Media Club’s first birthday, I let an AI tear my brand apart on camera. They paid me for it. Let me be upfront about what this was. It start...",
           "image": "https://danielkishimoto.com/wp-content/uploads/2026/06/Frame-5-4.png"
         },
         {
@@ -122,7 +125,7 @@
             "siteUrl": "https://danielkishimoto.com/",
             "feedUrl": "https://danielkishimoto.com/feed/"
           },
-          "summary": "I’ve been working on GMC’s rebrand for months. Brand identity, design system, a custom SDK to generate marketing assets. Last week Anthropic launched Claude Design — and it rebuilt my entire brandbook in five minutes. I don’t know whether to laugh or feel validated. Probably both. I wasn’t just working on GMC’s visual identity — […]",
+          "summary": "I’ve been working on GMC’s rebrand for months. Brand identity, design system, a custom SDK to generate marketing assets. Last week Anthropic launched Claude Design — and it rebuilt my entire brandbook in five minutes. I don’t know whether to laugh or feel validated. Probably b...",
           "image": "https://danielkishimoto.com/wp-content/uploads/2026/04/cover-post-1.png"
         },
         {
@@ -135,12 +138,13 @@
             "siteUrl": "https://danielkishimoto.com/",
             "feedUrl": "https://danielkishimoto.com/feed/"
           },
-          "summary": "What is “All you need”? A series cutting through AI hype. No tutorials. No hacks that expire in three months. Just key concepts that actually matter—the ones that stick around while everything else changes. Check the index for what’s coming. Every week there’s a new model. A prompting technique you “have to know.” A Twitter […]",
+          "summary": "What is “All you need”? A series cutting through AI hype. No tutorials. No hacks that expire in three months. Just key concepts that actually matter—the ones that stick around while everything else changes. Check the index for what’s coming. Every week there’s a new model. A p...",
           "image": "https://danielkishimoto.com/wp-content/uploads/2026/02/ai-fluency-2.jpg"
         }
       ]
     },
     {
+      "id": "mere-mortal-dev",
       "name": "Mere Mortal Dev",
       "siteUrl": "https://www.youtube.com/@meremortaldev",
       "feedUrl": "https://www.youtube.com/@meremortaldev",

--- a/test/community-feed-notifier-state.test.mjs
+++ b/test/community-feed-notifier-state.test.mjs
@@ -3,6 +3,7 @@ import {
   buildDiscordPayload,
   buildMessage,
   defaultState,
+  initializeNewFeedSources,
   migrateStateItemIds,
   parseState,
   upsertStateRecord,
@@ -32,8 +33,48 @@ test("defaultState creates an empty notifier state", () => {
     initializedAt: null,
     updatedAt: null,
     items: {},
+    sources: {},
     events: {},
     weeklyDigest: {},
+  });
+});
+
+test("initializeNewFeedSources records new sources without treating existing ones as new", () => {
+  const state = defaultState();
+  state.sources["existing"] = { initializedAt: "2026-04-01T00:00:00.000Z" };
+  const sources = [
+    { id: "existing", feedUrl: "https://example.com/existing.xml" },
+    { id: "new-source", feedUrl: "https://example.com/new.xml" },
+  ];
+
+  const newlyInitialized = initializeNewFeedSources(
+    state,
+    sources,
+    "2026-04-25T05:35:48.687Z",
+  );
+
+  expect([...newlyInitialized]).toEqual(["new-source"]);
+  expect(state.sources["new-source"]).toEqual({
+    initializedAt: "2026-04-25T05:35:48.687Z",
+    feedUrl: "https://example.com/new.xml",
+  });
+});
+
+test("initializeNewFeedSources migrates sources represented by existing items", () => {
+  const state = defaultState();
+  state.initializedAt = "2026-04-01T00:00:00.000Z";
+  state.items["existing::post-1"] = sampleItem();
+
+  const newlyInitialized = initializeNewFeedSources(
+    state,
+    [{ id: "example-author", feedUrl: "https://example.com/feed.xml" }],
+    "2026-04-25T05:35:48.687Z",
+  );
+
+  expect([...newlyInitialized]).toEqual([]);
+  expect(state.sources["example-author"]).toEqual({
+    initializedAt: "2026-04-01T00:00:00.000Z",
+    feedUrl: "https://example.com/feed.xml",
   });
 });
 
@@ -53,6 +94,7 @@ test("parseState normalizes missing or malformed state fields", () => {
     initializedAt: null,
     updatedAt: "2026-04-25T05:35:48.687Z",
     items: {},
+    sources: {},
     events: {},
     weeklyDigest: {},
   });

--- a/test/community-feed-reader.test.mjs
+++ b/test/community-feed-reader.test.mjs
@@ -4,6 +4,8 @@ import path from "node:path";
 import { expect, test } from "vitest";
 import {
   fetchFeedItems,
+  fetchRawFeedItems,
+  enrichNotifierItemWithLinkedPageImage,
   loadMemberFeeds,
   normalizeNotifierItem,
   parseDate,
@@ -94,6 +96,35 @@ test("resolveFeedUrl resolves YouTube handles to channel feeds", async () => {
   );
 });
 
+test("fetchRawFeedItems retries a transient YouTube feed failure", async () => {
+  let attempts = 0;
+  const parser = {
+    async parseString(xml) {
+      expect(xml).toBe("<feed />");
+      return { items: [] };
+    },
+  };
+  const items = await fetchRawFeedItems(
+    {
+      id: "video-author",
+      name: "Video Author",
+      feedUrl: "https://www.youtube.com/feeds/videos.xml?channel_id=UC1234567890123456789012",
+      siteUrl: "https://www.youtube.com/@example",
+    },
+    {
+      parser,
+      fetchTextFn: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("HTTP 404");
+        return "<feed />";
+      },
+    },
+  );
+
+  expect(items).toEqual([]);
+  expect(attempts).toBe(2);
+});
+
 test("parseYoutubeChannelId supports common channel id locations", () => {
   expect(
     parseYoutubeChannelId('{"channelId":"UCabcdefabcdefabcdefabcd"}'),
@@ -169,6 +200,28 @@ test("normalizeNotifierItem extracts image URLs from feed item media", () => {
   );
 
   expect(item.imageUrl).toBe("https://example.com/images/post-1.jpg");
+});
+
+test("enrichNotifierItemWithLinkedPageImage finds WordPress featured images", async () => {
+  const item = normalizeNotifierItem(
+    {
+      guid: "post-1",
+      title: "Post One",
+      link: "https://example.com/post-1",
+      isoDate: "2026-04-25T05:35:48.687Z",
+    },
+    {
+      id: "example-author",
+      name: "Example Author",
+      feedUrl: "https://example.com/feed.xml",
+      siteUrl: "https://example.com/",
+    },
+  );
+  const enriched = await enrichNotifierItemWithLinkedPageImage(item, {
+    fetchTextFn: async () => '<img class="wp-post-image" src="/featured.jpg">',
+  });
+
+  expect(enriched.imageUrl).toBe("https://example.com/featured.jpg");
 });
 
 test("fetchFeedItems fetches, normalizes, dedupes, sorts, and limits items", async () => {

--- a/test/fetch-feeds.test.mjs
+++ b/test/fetch-feeds.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import {
   enrichItemWithLinkedPageImage,
   extractPageImage,
+  getCachedFeedForSource,
   isImageMediaCandidate,
   resolveFeedImage,
 } from "../scripts/fetch-feeds.mjs";
@@ -13,6 +14,11 @@ const blogSource = {
 };
 
 describe("composite feed image selection", () => {
+  test("finds a cached source by stable feed identity", () => {
+    const cached = { feeds: [{ name: "Example Author", feedUrl: blogSource.feedUrl, items: [{ id: "old" }] }] };
+    expect(getCachedFeedForSource(cached, blogSource)?.items).toEqual([{ id: "old" }]);
+  });
+
   test("accepts image enclosures and rejects video enclosures", () => {
     expect(
       isImageMediaCandidate({


### PR DESCRIPTION
## What
- polish Next Meetup and calendar metadata spacing
- align feed excerpts and image handling across the site and Discord
- retry transient YouTube feed failures and preserve per-source stale snapshots
- suppress historical backlog when a new feed source is onboarded
- update the homepage and agent-readiness roadmaps

## Verification
- npm run check
- npm run build
- 129 tests passing
- production build completed with agent artifact verification