### PR TITLE
Allow Cloudflare Web Analytics through CSP

### DIFF
--- a/scripts/security-headers.mjs
+++ b/scripts/security-headers.mjs
@@ -26,7 +26,7 @@ export function buildContentSecurityPolicy(scriptHashes) {
     "object-src 'none'",
     "frame-ancestors 'none'",
     "form-action 'self'",
-    `script-src 'self' ${scriptHashes.join(" ")} https://www.googletagmanager.com`,
+    `script-src 'self' ${scriptHashes.join(" ")} https://www.googletagmanager.com https://static.cloudflareinsights.com`,
     "script-src-attr 'none'",
     "style-src 'self'",
     "style-src-attr 'none'",

--- a/test/security-headers.test.mjs
+++ b/test/security-headers.test.mjs
@@ -20,6 +20,7 @@ describe("Cloudflare security headers", () => {
 
     expect(hashes).toEqual([`'sha256-${expected}'`]);
     expect(policy).toContain("script-src 'self'");
+    expect(policy).toContain("https://static.cloudflareinsights.com");
     expect(policy).toContain("script-src-attr 'none'");
     expect(policy).not.toContain("'unsafe-inline'");
     expect(policy).not.toContain("'unsafe-eval'");


### PR DESCRIPTION
## What changed

- allow Cloudflare Web Analytics to load `static.cloudflareinsights.com` under the generated `script-src` policy
- add regression coverage for the Cloudflare Insights origin

## Why

Cloudflare automatically injects its Web Analytics beacon after the Astro build. The generated CSP allowed Google Tag Manager but not Cloudflare Insights, so browsers blocked `beacon.min.js` on page load.

This keeps the strict hash-based CSP intact without adding `unsafe-inline`. Cloudflare's separate JavaScript Detections inline-script warning remains a dashboard configuration concern and is intentionally outside this PR.

## Validation

- `npx vitest run test/security-headers.test.mjs`
- `npm run build`
- verified generated `dist/_headers` includes `https://static.cloudflareinsights.com`
- `git diff --check`
